### PR TITLE
feat(math): add initial math package

### DIFF
--- a/math/math.go
+++ b/math/math.go
@@ -60,10 +60,15 @@ var (
 	mathModule skylark.StringDict
 )
 
+const tau = math.Pi * 2
+const oneRad = tau / 360
+
 // LoadModule loads the math module.
 // It is concurrency-safe and idempotent.
 func LoadModule() (skylark.StringDict, error) {
 	once.Do(func() {
+		inf := math.Inf(1)
+		nan := math.NaN()
 		mathModule = skylark.StringDict{
 			"math": skylarkstruct.FromStringDict(skylarkstruct.Default, skylark.StringDict{
 				"ceil":  skylark.NewBuiltin("ceil", ceil),
@@ -91,6 +96,13 @@ func LoadModule() (skylark.StringDict, error) {
 				"cosh":  skylark.NewBuiltin("cosh", cosh),
 				"sinh":  skylark.NewBuiltin("sinh", sinh),
 				"tanh":  skylark.NewBuiltin("tanh", tanh),
+
+				"e":   skylark.Float(math.E),
+				"pi":  skylark.Float(math.Pi),
+				"tau": skylark.Float(tau),
+				"phi": skylark.Float(math.Phi),
+				"inf": skylark.Float(inf),
+				"nan": skylark.Float(nan),
 			}),
 		}
 	})
@@ -115,7 +127,7 @@ func ceil(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs
 	return skylark.Float(math.Ceil(float64(x))), nil
 }
 
-//
+// Return the absolute value of x
 func fabs(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var x skylark.Float
 	if err := skylark.UnpackArgs("fabs", args, kwargs, "x", &x); err != nil {
@@ -133,6 +145,7 @@ func exp(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs 
 	return skylark.Float(math.Exp(float64(x))), nil
 }
 
+// Return the square root of x
 func sqrt(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var x skylark.Float
 	if err := skylark.UnpackArgs("sqrt", args, kwargs, "x", &x); err != nil {

--- a/math/math.go
+++ b/math/math.go
@@ -1,0 +1,142 @@
+/*
+Package math defines mathimatical functions, it's intented to be a drop-in
+subset of python's math module for starlark:
+https://docs.python.org/3/library/math.html
+
+Currently defined functions are as follows:
+
+Number-theoretic and representation functions:
+
+	ceil(x) - Return the ceiling of x, the smallest integer greater than or equal to x.
+	fabs(x) - Return the absolute value of x.
+	floor(x) - Return the floor of x, the largest integer less than or equal to x.
+
+Power and logarithmic functions
+
+	exp(x) - Return e raised to the power x, where e = 2.718281… is the base of natural logarithms
+	sqrt(x) - Return the square root of x.
+
+Trigonometric functions
+
+	acos(x) - Return the arc cosine of x, in radians.
+	asin(x) - Return the arc sine of x, in radians.
+	atan(x) - Return the arc tangent of x, in radians.
+	atan2(y, x) - Return atan(y / x), in radians. The result is between -pi and pi. The vector in the plane from the origin to point (x, y) makes this angle with the positive X axis. The point of atan2() is that the signs of both inputs are known to it, so it can compute the correct quadrant for the angle. For example, atan(1) and atan2(1, 1) are both pi/4, but atan2(-1, -1) is -3*pi/4.
+	cos(x) - Return the cosine of x radians.
+	hypot(x, y) - Return the Euclidean norm, sqrt(x*x + y*y). This is the length of the vector from the origin to point (x, y).
+	sin(x) - Return the sine of x radians.
+	tan(x) - Return the tangent of x radians.
+
+Angular conversion
+
+	degrees(x) - Convert angle x from radians to degrees.
+	radians(x) - Convert angle x from degrees to radians.
+
+Hyperbolic functions - Hyperbolic functions are analogs of trigonometric functions that are based on hyperbolas instead of circles.
+
+	acosh(x) - Return the inverse hyperbolic cosine of x.
+	asinh(x) - Return the inverse hyperbolic sine of x.
+	atanh(x) - Return the inverse hyperbolic tangent of x.
+	cosh(x) - Return the hyperbolic cosine of x.
+	sinh(x) - Return the hyperbolic sine of x.
+	tanh(x) - Return the hyperbolic tangent of x.
+*/
+package math
+
+import (
+	"math"
+	"sync"
+
+	"github.com/google/skylark"
+	"github.com/google/skylark/skylarkstruct"
+)
+
+// ModuleName defines the expected name for this Module when used
+// in skylark's load() function, eg: load('math.sky', 'math')
+const ModuleName = "math.sky"
+
+var (
+	once       sync.Once
+	mathModule skylark.StringDict
+)
+
+// LoadModule loads the math module.
+// It is concurrency-safe and idempotent.
+func LoadModule() (skylark.StringDict, error) {
+	once.Do(func() {
+		mathModule = skylark.StringDict{
+			"math": skylarkstruct.FromStringDict(skylarkstruct.Default, skylark.StringDict{
+				"ceil":  skylark.NewBuiltin("ceil", ceil),
+				"fabs":  skylark.NewBuiltin("fabs", fabs),
+				"floor": skylark.NewBuiltin("floor", floor),
+
+				"exp":  skylark.NewBuiltin("exp", exp),
+				"sqrt": skylark.NewBuiltin("sqrt", sqrt),
+
+				"acos":  skylark.NewBuiltin("acos", acos),
+				"asin":  skylark.NewBuiltin("asin", asin),
+				"atan":  skylark.NewBuiltin("atan", atan),
+				"atan2": skylark.NewBuiltin("atan2", atan2),
+				"cos":   skylark.NewBuiltin("cos", cos),
+				"hypot": skylark.NewBuiltin("hypot", hypot),
+				"sin":   skylark.NewBuiltin("sin", sin),
+				"tan":   skylark.NewBuiltin("tan", tan),
+
+				"degrees": skylark.NewBuiltin("degrees", degrees),
+				"radians": skylark.NewBuiltin("radians", radians),
+
+				"acosh": skylark.NewBuiltin("acosh", acosh),
+				"asinh": skylark.NewBuiltin("asinh", asinh),
+				"atanh": skylark.NewBuiltin("atanh", atanh),
+				"cosh":  skylark.NewBuiltin("cosh", cosh),
+				"sinh":  skylark.NewBuiltin("sinh", sinh),
+				"tanh":  skylark.NewBuiltin("tanh", tanh),
+			}),
+		}
+	})
+	return mathModule, nil
+}
+
+// Return the floor of x, the largest integer less than or equal to x.
+func floor(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("floor", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Floor(float64(x))), nil
+}
+
+// Return the ceiling of x, the smallest integer greater than or equal to x
+func ceil(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("ceil", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Ceil(float64(x))), nil
+}
+
+//
+func fabs(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("fabs", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Abs(float64(x))), nil
+}
+
+// Return e raised to the power x, where e = 2.718281… is the base of natural logarithms.
+func exp(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("exp", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Exp(float64(x))), nil
+}
+
+func sqrt(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("sqrt", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Sqrt(float64(x))), nil
+}

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -1,0 +1,40 @@
+package math
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/skylark"
+	"github.com/google/skylark/resolve"
+	"github.com/google/skylark/skylarktest"
+)
+
+func TestFile(t *testing.T) {
+	resolve.AllowFloat = true
+	thread := &skylark.Thread{Load: newLoader()}
+	skylarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := skylark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	if err != nil {
+		if ee, ok := err.(*skylark.EvalError); ok {
+			t.Error(ee.Backtrace())
+		} else {
+			t.Error(err)
+		}
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func newLoader() func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
+	return func(thread *skylark.Thread, module string) (skylark.StringDict, error) {
+		switch module {
+		case ModuleName:
+			return LoadModule()
+		case "assert.sky":
+			return skylarktest.LoadAssertModule()
+		}
+
+		return nil, fmt.Errorf("invalid module")
+	}
+}

--- a/math/testdata/test.sky
+++ b/math/testdata/test.sky
@@ -1,15 +1,12 @@
 load('math.sky', 'math')
 load('assert.sky', 'assert')
 
-
 assert.eq(math.ceil(0.5), 1.0)
 assert.eq(math.fabs(-2.0), 2.0)
 assert.eq(math.floor(0.5), 0)
 
-
 assert.eq(math.exp(2.0), 7.38905609893065)
 assert.eq(math.sqrt(4.0), 2.0)
-
 
 assert.eq(math.acos(1.0), 0)
 assert.eq(math.asin(1.0), 1.5707963267948966)
@@ -29,3 +26,10 @@ assert.eq(math.atanh(0.5), 0.5493061443340548)
 assert.eq(math.cosh(1.0), 1.5430806348152437)
 assert.eq(math.sinh(1.0), 1.1752011936438014)
 assert.eq(math.tanh(1.0), 0.7615941559557649)
+
+assert.eq(math.e, 2.7182818284590452)
+assert.eq(math.pi, 3.1415926535897932)
+assert.eq(math.tau, 6.2831853071795864)
+assert.eq(math.phi, 1.6180339887498948)
+assert.eq(math.inf, math.inf + 1)
+assert.eq(math.nan == math.nan, False)

--- a/math/testdata/test.sky
+++ b/math/testdata/test.sky
@@ -1,0 +1,31 @@
+load('math.sky', 'math')
+load('assert.sky', 'assert')
+
+
+assert.eq(math.ceil(0.5), 1.0)
+assert.eq(math.fabs(-2.0), 2.0)
+assert.eq(math.floor(0.5), 0)
+
+
+assert.eq(math.exp(2.0), 7.38905609893065)
+assert.eq(math.sqrt(4.0), 2.0)
+
+
+assert.eq(math.acos(1.0), 0)
+assert.eq(math.asin(1.0), 1.5707963267948966)
+assert.eq(math.atan(1.0), 0.7853981633974483)
+assert.eq(math.atan2(1.0,1.0), 0.7853981633974483)
+assert.eq(math.cos(1.0), 0.5403023058681398)
+assert.eq(math.hypot(1.0,1.0), 1.4142135623730951)
+assert.eq(math.sin(1.0), 0.8414709848078965)
+assert.eq(math.tan(1.0), 1.557407724654902)
+
+assert.eq(math.degrees(1.0), 57.29577951308232)
+assert.eq(math.radians(1.0), 0.017453292519943295)
+
+assert.eq(math.acosh(1.0), 0)
+assert.eq(math.asinh(1.0), 0.8813735870195432)
+assert.eq(math.atanh(0.5), 0.5493061443340548)
+assert.eq(math.cosh(1.0), 1.5430806348152437)
+assert.eq(math.sinh(1.0), 1.1752011936438014)
+assert.eq(math.tanh(1.0), 0.7615941559557649)

--- a/math/trig.go
+++ b/math/trig.go
@@ -78,8 +78,6 @@ func tan(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs 
 	return skylark.Float(math.Tan(float64(x))), nil
 }
 
-const oneRad = math.Pi / 180
-
 // degrees(x) - Convert angle x from radians to degrees.
 func degrees(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
 	var x skylark.Float

--- a/math/trig.go
+++ b/math/trig.go
@@ -1,0 +1,153 @@
+package math
+
+import (
+	"math"
+
+	"github.com/google/skylark"
+)
+
+// Return the arc cosine of x, in radians.
+func acos(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("acos", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Acos(float64(x))), nil
+}
+
+// asin(x) - Return the arc sine of x, in radians.
+func asin(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("asin", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Asin(float64(x))), nil
+}
+
+// atan(x) - Return the arc tangent of x, in radians.
+func atan(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("atan", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Atan(float64(x))), nil
+}
+
+// atan2(y, x) - Return atan(y / x), in radians. The result is between -pi and pi. The vector in the plane from the origin to point (x, y) makes this angle with the positive X axis. The point of atan2() is that the signs of both inputs are known to it, so it can compute the correct quadrant for the angle. For example, atan(1) and atan2(1, 1) are both pi/4, but atan2(-1, -1) is -3*pi/4.
+func atan2(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x, y skylark.Float
+	if err := skylark.UnpackArgs("atan2", args, kwargs, "y", &y, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Atan2(float64(y), float64(x))), nil
+}
+
+// cos(x) - Return the cosine of x radians.
+func cos(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("cos", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Cos(float64(x))), nil
+}
+
+// hypot(x, y) - Return the Euclidean norm, sqrt(x*x + y*y). This is the length of the vector from the origin to point (x, y).
+func hypot(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x, y skylark.Float
+	if err := skylark.UnpackArgs("hypot", args, kwargs, "x", &x, "y", &y); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Hypot(float64(x), float64(y))), nil
+}
+
+// sin(x) - Return the sine of x radians.
+func sin(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("sin", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Sin(float64(x))), nil
+}
+
+// tan(x) - Return the tangent of x radians.
+func tan(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("tan", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Tan(float64(x))), nil
+}
+
+const oneRad = math.Pi / 180
+
+// degrees(x) - Convert angle x from radians to degrees.
+func degrees(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("degrees", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(float64(x) / oneRad), nil
+}
+
+// radians(x) - Convert angle x from degrees to radians.
+func radians(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("radians", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(float64(x) * oneRad), nil
+}
+
+// acosh(x) - Return the inverse hyperbolic cosine of x.
+func acosh(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("acosh", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Acosh(float64(x))), nil
+}
+
+// asinh(x) - Return the inverse hyperbolic sine of x.
+func asinh(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("asinh", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Asinh(float64(x))), nil
+}
+
+// atanh(x) - Return the inverse hyperbolic tangent of x.
+func atanh(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("atanh", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Atanh(float64(x))), nil
+}
+
+// cosh(x) - Return the hyperbolic cosine of x.
+func cosh(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("cosh", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Cosh(float64(x))), nil
+}
+
+// sinh(x) - Return the hyperbolic sine of x.
+func sinh(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("sinh", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Sinh(float64(x))), nil
+}
+
+// tanh(x) - Return the hyperbolic tangent of x.
+func tanh(thread *skylark.Thread, _ *skylark.Builtin, args skylark.Tuple, kwargs []skylark.Tuple) (skylark.Value, error) {
+	var x skylark.Float
+	if err := skylark.UnpackArgs("tanh", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	return skylark.Float(math.Tanh(float64(x))), nil
+}


### PR DESCRIPTION
@stuartlynn, this repo is our crack at a standard library for skylark (recently renamed to _starlark_). Qri makes any module defined here available with a starlark `load` statement. This PR adds some math primitives you'd asked for, I'd love your review to see if anything you need is missing.

Modules here are often implemented as thin wrappers around the go standard library, conformed wherever possible to standard / popular python modules. in this case the function names are almost the exact same between go & [python 3.7](https://docs.python.org/3/library/math.html).

If merged, you'd be able to do stuff like the following in Qri once we cut a release that includes the math module:

```python
load('math.sky', 'math')

math.cos(1.0)       # 0.5403023058681398
math.sin(1.0)       # 0.8414709848078965
math.tan(1.0)       # 1.557407724654902
math.hypot(1.0,1.0) # 1.4142135623730951
```

lots more examples in the testdata/test.sky file in this PR.