### PR TITLE
refactor(.star): Complete conversion to .star, starlark name switch

### DIFF
--- a/encoding/base64/base64.go
+++ b/encoding/base64/base64.go
@@ -13,8 +13,8 @@ import (
 )
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('encoding/base64.sky', 'base64')
-const ModuleName = "encoding/base64.sky"
+// in starlark's load() function, eg: load('encoding/base64.star', 'base64')
+const ModuleName = "encoding/base64.star"
 
 var (
 	once         sync.Once

--- a/encoding/base64/base64_test.go
+++ b/encoding/base64/base64_test.go
@@ -31,7 +31,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/encoding/base64/testdata/test.star
+++ b/encoding/base64/testdata/test.star
@@ -1,5 +1,5 @@
-load('encoding/base64.sky', 'base64')
-load('assert.sky', 'assert')
+load('encoding/base64.star', 'base64')
+load('assert.star', 'assert')
 
 assert.eq(base64.encode("hello"), "aGVsbG8=")
 assert.eq(base64.encode("hello", encoding="standard_raw"), "aGVsbG8")

--- a/html/html.go
+++ b/html/html.go
@@ -15,8 +15,8 @@ func AsString(x starlark.Value) (string, error) {
 }
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('html.sky', 'html')
-const ModuleName = "html.sky"
+// in starlark's load() function, eg: load('html.star', 'html')
+const ModuleName = "html.star"
 
 // LoadModule loads the html module
 func LoadModule() (starlark.StringDict, error) {

--- a/html/html_test.go
+++ b/html/html_test.go
@@ -36,7 +36,7 @@ func TestModule(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 
 	// Execute test file
-	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -48,7 +48,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return starlark.StringDict{"html": starlark.NewBuiltin("html", NewDocument)}, nil
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/html/testdata/test.star
+++ b/html/testdata/test.star
@@ -1,5 +1,5 @@
-load('html.sky', 'html')
-load('assert.sky', 'assert')
+load('html.star', 'html')
+load('assert.star', 'assert')
 
 htmlstr = """
 <!DOCTYPE html>

--- a/http/http.go
+++ b/http/http.go
@@ -21,8 +21,8 @@ func AsString(x starlark.Value) (string, error) {
 }
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('http.sky', 'http')
-const ModuleName = "http.sky"
+// in starlark's load() function, eg: load('http.star', 'http')
+const ModuleName = "http.star"
 
 var (
 	// Client is the http client used to create the http module. override with

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -55,7 +55,7 @@ func TestNewModule(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 
 	// Execute test file
-	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -67,7 +67,7 @@ func newLoader(ds *dataset.Dataset) func(thread *starlark.Thread, module string)
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/http/testdata/test.star
+++ b/http/testdata/test.star
@@ -1,5 +1,5 @@
-load('http.sky', 'http')
-load('assert.sky', 'assert')
+load('http.star', 'http')
+load('assert.star', 'assert')
 
 res_1 = http.get(test_server_url, params={ "a" : "b", "c" : "d"})
 assert.eq(res_1.url, test_server_url + "?a=b&c=d")

--- a/math/math.go
+++ b/math/math.go
@@ -52,8 +52,8 @@ import (
 )
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('math.sky', 'math')
-const ModuleName = "math.sky"
+// in starlark's load() function, eg: load('math.star', 'math')
+const ModuleName = "math.star"
 
 var (
 	once       sync.Once

--- a/math/math_test.go
+++ b/math/math_test.go
@@ -15,7 +15,7 @@ func TestFile(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 
 	// Execute test file
-	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
 	if err != nil {
 		if ee, ok := err.(*starlark.EvalError); ok {
 			t.Error(ee.Backtrace())
@@ -31,7 +31,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/math/testdata/test.star
+++ b/math/testdata/test.star
@@ -1,5 +1,5 @@
-load('math.sky', 'math')
-load('assert.sky', 'assert')
+load('math.star', 'math')
+load('assert.star', 'assert')
 
 assert.eq(math.ceil(0.5), 1.0)
 assert.eq(math.fabs(-2.0), 2.0)

--- a/re/re.go
+++ b/re/re.go
@@ -26,8 +26,8 @@ import (
 )
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('re.sky', 're')
-const ModuleName = "re.sky"
+// in starlark's load() function, eg: load('re.star', 're')
+const ModuleName = "re.star"
 
 var (
 	once     sync.Once

--- a/re/re_test.go
+++ b/re/re_test.go
@@ -13,7 +13,7 @@ func TestFile(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 
 	// Execute test file
-	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -25,7 +25,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/re/testdata/test.star
+++ b/re/testdata/test.star
@@ -1,5 +1,5 @@
-load("re.sky", "re")
-load("assert.sky", "assert")
+load("re.star", "re")
+load("assert.star", "assert")
 
 pattern = "(\w*)\s*(ADD|REM|DEL|EXT|TRF)\s*(.*)\s*(NAT|INT)\s*(.*)\s*(\(\w{2}\))\s*(.*)"
 test = "EDM ADD FROM INJURED NAT Jordan BEAULIEU (DB) Western University"

--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -1,5 +1,5 @@
-load('time.sky', 'time')
-load('assert.sky', 'assert')
+load('time.star', 'time')
+load('assert.star', 'assert')
 
 assert.eq(time.time("2011-04-22T13:33:48Z"), time.time("2011-04-22T13:33:48Z"))
 assert.eq(time.zero, time.time("0001-01-01T00:00:00Z"))

--- a/time/time.go
+++ b/time/time.go
@@ -61,8 +61,8 @@ import (
 )
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('time.sky', 'time')
-const ModuleName = "time.sky"
+// in starlark's load() function, eg: load('time.star', 'time')
+const ModuleName = "time.star"
 
 var (
 	once       sync.Once
@@ -94,9 +94,9 @@ time = struct(
 )
 `)
 
-		// filename := DataFile("time", "time.sky")
+		// filename := DataFile("time", "time.star")
 		thread := new(starlark.Thread)
-		timeModule, timeError = starlark.ExecFile(thread, "time.sky", file, predeclared)
+		timeModule, timeError = starlark.ExecFile(thread, "time.star", file, predeclared)
 	})
 	return timeModule, timeError
 }

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -13,7 +13,7 @@ func TestFile(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 
 	// Execute test file
-	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -25,7 +25,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/xlsx/testdata/test.star
+++ b/xlsx/testdata/test.star
@@ -1,5 +1,5 @@
-load('xlsx.sky', 'xlsx')
-load('assert.sky', 'assert')
+load('xlsx.star', 'xlsx')
+load('assert.star', 'assert')
 
 file_1 = xlsx.get_url(test_server_url + "/eg_one.xlsx")
 

--- a/xlsx/xlsx.go
+++ b/xlsx/xlsx.go
@@ -10,8 +10,8 @@ import (
 )
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('xlsx.sky', 'xlsx')
-const ModuleName = "xlsx.sky"
+// in starlark's load() function, eg: load('xlsx.star', 'xlsx')
+const ModuleName = "xlsx.star"
 
 // LoadModule creates an xlsx Module
 func LoadModule() (starlark.StringDict, error) {

--- a/xlsx/xlsx_test.go
+++ b/xlsx/xlsx_test.go
@@ -18,7 +18,7 @@ func TestFromURL(t *testing.T) {
 	starlarktest.SetReporter(thread, t)
 
 	// Execute test file
-	_, err := starlark.ExecFile(thread, "testdata/test.sky", nil, nil)
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -30,7 +30,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 

--- a/zipfile/testdata/test.star
+++ b/zipfile/testdata/test.star
@@ -1,5 +1,5 @@
-load("assert.sky", "assert")
-load("zipfile.sky", "ZipFile")
+load("assert.star", "assert")
+load("zipfile.star", "ZipFile")
 
 zr = ZipFile(hello_world_zip)
 assert.eq(zr.namelist(), ["testdata/", "testdata/world/","testdata/world/world.txt","testdata/hello.txt"])

--- a/zipfile/zip.go
+++ b/zipfile/zip.go
@@ -17,8 +17,8 @@ import (
 )
 
 // ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('zipfile.sky', 'zipfile')
-const ModuleName = "zipfile.sky"
+// in starlark's load() function, eg: load('zipfile.star', 'zipfile')
+const ModuleName = "zipfile.star"
 
 var (
 	once          sync.Once

--- a/zipfile/zip_test.go
+++ b/zipfile/zip_test.go
@@ -19,7 +19,7 @@ func TestFile(t *testing.T) {
 	}
 
 	// Execute test file
-	_, err = starlark.ExecFile(thread, "testdata/test.sky", nil, starlark.StringDict{
+	_, err = starlark.ExecFile(thread, "testdata/test.star", nil, starlark.StringDict{
 		"hello_world_zip": starlark.String(zipBytes),
 	})
 	if err != nil {
@@ -33,7 +33,7 @@ func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDi
 		switch module {
 		case ModuleName:
 			return LoadModule()
-		case "assert.sky":
+		case "assert.star":
 			return starlarktest.LoadAssertModule()
 		}
 


### PR DESCRIPTION
builds on #6. This is a breaking change that modifies the name of all package imports