### PR TITLE
feat(geo): add geo module

### DIFF
--- a/geo/doc.go
+++ b/geo/doc.go
@@ -1,40 +1,71 @@
 /*Package geo defines geographic operations
 
   outline: geo
-    geo defines geographic operations
+    geo defines geographic operations in two-dimensional space
+
     functions:
-      point(lat,lng)
-        Point constructor takes an x(longitude) and y(latitude) value and returns a Point object
-        params
-          lat float
+      Point(x,y)
+        Point constructor, takes an x(longitude) and y(latitude) value and
+        returns a Point object
+        params:
           lng float
-      within(geomA,geomB)
+            x-dimension value (longitude if using geodesic space)
+          lat float
+            y-dimension value (latitude if using geodesic space)
+      Line(points)
+        Line constructor. Takes either an array of coordinate pairs or an array
+        of point objects and returns the line that connects them.
+        params:
+          points [[]float|Point]
+            list of points on the line
+      Polygon(rings)
+        Polygon constructor. Takes a list of lists of coordinate pairs (or point
+        objects) that define the outer boundary and any holes / inner boundaries
+        that represent a polygon. In GIS tradition, lists of coordinates that
+        wind clockwise are filled regions and  anti-clockwise represent holes.
+        params:
+          rings [Line]
+            list of closed lines that constitute the polygon
+      MultiPolygon(polygons)
+        MultiPolygon constructor. MultiPolygon groups a list of polygons to
+        behave like a single polygon
+        params:
+          polygons [Polygon]
+      within(geom,polygon)
         Returns True if geometry A is entirely contained by geometry B
         params:
-          a [point,line,polygon]
+          geom [point,line,polygon]
             maybe-inner geometry
-          b [point,line,polygon]
-            maybe-outer geometery
-      intersects(geomA,geomB)
-        Similar to within but part of geometry B can lie outside of geometry A and it will still return True
+          polygon [Polygon,MultiPolygon]
+            maybe-outer polygon
+      parseGeoJSON(data) (geoms, properties)
+        Parses string data in IETF-7946 format (https://tools.ietf.org/html/rfc7946)
+        returning a list of geometries and equal-length list of properties for
+        each geometry
+        params:
+          data string
+            string of GeoJSON data
     types:
-      point
+      Point
+        a two-dimensional point in space
         methods:
-          buffer(x int)
-            Generates a buffered region of x units around a point
           distance(p2 point)
             Euclidian Distance
           distanceGeodesic(p2 point)
             Distance on the surface of a sphere with the same radius as Earth
-          KNN()
-            Given a target point T and an array of other points, return the K nearest points to T
-          greatCircle(p2 point)
-            Returns the great circle line segment to point 2
-      line
+      Line
+        an ordered list of points that define a line
         methods:
-          buffer()
-          length()
-          geodesicLength()
-      polygon
+          length() float
+            Euclidian Length
+          geodesicLength() float
+            Line length on the surface of a sphere with the same radius as Earth
+      Polygon
+        an ordered list of closed lines (rings) that define a shape. lists of
+        coordinates that wind clockwise are filled regions and  anti-clockwise
+        represent holes.
+      MultiPolygon
+        MultiPolygon groups a list of polygons to behave like a single polygon
+
 */
 package geo

--- a/geo/doc.go
+++ b/geo/doc.go
@@ -4,21 +4,23 @@
     geo defines geographic operations in two-dimensional space
 
     functions:
-      Point(x,y)
+      Point(x,y) Point
         Point constructor, takes an x(longitude) and y(latitude) value and
         returns a Point object
         params:
-          lng float
+          x float
             x-dimension value (longitude if using geodesic space)
-          lat float
+          y float
             y-dimension value (latitude if using geodesic space)
-      Line(points)
+      Line(points) Line
         Line constructor. Takes either an array of coordinate pairs or an array
-        of point objects and returns the line that connects them.
+        of point objects and returns the line that connects them. Points do not
+        need to be collinear, providing a single point returns a line with a
+        length of 0
         params:
           points [[]float|Point]
             list of points on the line
-      Polygon(rings)
+      Polygon(rings) Polygon
         Polygon constructor. Takes a list of lists of coordinate pairs (or point
         objects) that define the outer boundary and any holes / inner boundaries
         that represent a polygon. In GIS tradition, lists of coordinates that
@@ -26,13 +28,13 @@
         params:
           rings [Line]
             list of closed lines that constitute the polygon
-      MultiPolygon(polygons)
+      MultiPolygon(polygons) MultiPolygon
         MultiPolygon constructor. MultiPolygon groups a list of polygons to
         behave like a single polygon
         params:
           polygons [Polygon]
-      within(geom,polygon)
-        Returns True if geometry A is entirely contained by geometry B
+      within(geom,polygon) bool
+        Returns True if geom is entirely contained by polygon
         params:
           geom [point,line,polygon]
             maybe-inner geometry
@@ -49,10 +51,16 @@
       Point
         a two-dimensional point in space
         methods:
-          distance(p2 point)
-            Euclidian Distance
-          distanceGeodesic(p2 point)
+          distance(p2) float
+            Euclidian Distance to the other point
+            params:
+              p2  point
+                point to measure distance to
+          distanceGeodesic(p2) float
             Distance on the surface of a sphere with the same radius as Earth
+            params:
+              p2 point
+                point to measure distance to
       Line
         an ordered list of points that define a line
         methods:

--- a/geo/doc.go
+++ b/geo/doc.go
@@ -1,0 +1,40 @@
+/*Package geo defines geographic operations
+
+  outline: geo
+    geo defines geographic operations
+    functions:
+      point(lat,lng)
+        Point constructor takes an x(longitude) and y(latitude) value and returns a Point object
+        params
+          lat float
+          lng float
+      within(geomA,geomB)
+        Returns True if geometry A is entirely contained by geometry B
+        params:
+          a [point,line,polygon]
+            maybe-inner geometry
+          b [point,line,polygon]
+            maybe-outer geometery
+      intersects(geomA,geomB)
+        Similar to within but part of geometry B can lie outside of geometry A and it will still return True
+    types:
+      point
+        methods:
+          buffer(x int)
+            Generates a buffered region of x units around a point
+          distance(p2 point)
+            Euclidian Distance
+          distanceGeodesic(p2 point)
+            Distance on the surface of a sphere with the same radius as Earth
+          KNN()
+            Given a target point T and an array of other points, return the K nearest points to T
+          greatCircle(p2 point)
+            Returns the great circle line segment to point 2
+      line
+        methods:
+          buffer()
+          length()
+          geodesicLength()
+      polygon
+*/
+package geo

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -12,9 +12,13 @@ import (
 	"go.starlark.net/starlarkstruct"
 )
 
-// ModuleName defines the expected name for this Module when used
-// in starlark's load() function, eg: load('geo.star', 'geo')
-const ModuleName = "geo.star"
+const (
+	// ModuleName defines the expected name for this Module when used
+	// in starlark's load() function, eg: load('geo.star', 'geo')
+	ModuleName = "geo.star"
+	// hash of NaN value in starlark
+	nan = 1618033
+)
 
 var (
 	once      sync.Once
@@ -47,7 +51,6 @@ func within(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, k
 	var (
 		a, b starlark.Value
 	)
-	v = starlark.None
 
 	if err = starlark.UnpackArgs("within", args, kwargs, "a", &a, "b", &b); err != nil {
 		return
@@ -96,8 +99,10 @@ func intersects(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	return starlark.None, fmt.Errorf("not finished: intersects")
 }
 
+// TODO(b5): move this to utils package as an exported type
 type builtinMethod func(fnname string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)
 
+// TODO(b5): move this to utils package as an exported function
 func addClosure(name string, recv starlark.Value, method builtinMethod) (*starlark.Builtin, error) {
 	// Allocate a closure over 'method'.
 	impl := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
@@ -111,7 +116,7 @@ func floatHash(f float64) (uint32, error) {
 	if isFinite(f) {
 		return finiteFloatToInt(f).Hash()
 	}
-	return 1618033, nil // NaN, +/-Inf
+	return nan, nil // NaN, +/-Inf
 }
 
 // isFinite reports whether f represents a finite rational value.

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -1,8 +1,15 @@
 package geo
 
 import (
+	"fmt"
+	"math"
+	"math/big"
+	"sort"
 	"sync"
 
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geo"
+	"github.com/paulmach/orb/planar"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -21,8 +28,187 @@ var (
 func LoadModule() (starlark.StringDict, error) {
 	once.Do(func() {
 		geoModule = starlark.StringDict{
-			"geo": starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{}),
+			"geo": starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+				"point": starlark.NewBuiltin("point", newPoint),
+			}),
 		}
 	})
 	return geoModule, nil
+}
+
+func newPoint(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+	var (
+		x, y     starlark.Value
+		lat, lng float64
+	)
+	v = starlark.None
+
+	if err = starlark.UnpackArgs("encode", args, kwargs, "x", &x, "y", &y); err != nil {
+		return
+	}
+
+	if lat, err = float64FromNumericValue(x); err != nil {
+		return
+	}
+	if lng, err = float64FromNumericValue(y); err != nil {
+		return
+	}
+
+	return Point{lat, lng}, nil
+}
+
+// Point is the starlark geographic point type
+type Point [2]float64
+
+// assert point is a starlark value
+var _ starlark.Value = (*Point)(nil)
+
+// String implements the starlark.Value interface
+func (p Point) String() string { return fmt.Sprintf("(%f,%f)", p[0], p[1]) }
+
+// Type implements the starlark.Value interface
+func (p Point) Type() string { return "point" }
+
+// Freeze implements the starlark.Value interface, point is immutable
+func (p Point) Freeze() {}
+
+// Truth implements the starlark.Value interface
+func (p Point) Truth() starlark.Bool {
+	return starlark.Bool(p[0] != 0 && p[1] != 0)
+}
+
+// Hash implements the starlark.Value interface
+func (p Point) Hash() (uint32, error) {
+	x, _ := floatHash(p[0])
+	y, _ := floatHash(p[1])
+	return x - y, nil
+}
+
+// Attr gets an attribute of point
+func (p Point) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "x", "lat":
+		return starlark.Float(p[0]), nil
+	case "y", "lng":
+		return starlark.Float(p[1]), nil
+	case "buffer":
+		return addClosure("buffer", p, p.buffer)
+	case "distance":
+		return addClosure("distance", p, p.distance)
+	case "distanceGeodesic":
+		return addClosure("distanceGeodesic", p, p.distanceGeodesic)
+	case "KNN":
+		return addClosure("KNN", p, p.knn)
+	default:
+		// attr does not exist
+		return nil, nil
+	}
+}
+
+// AttrNames returns all possible attribute names
+func (p Point) AttrNames() []string {
+	names := []string{
+		// attributes
+		"x", "y", "lat", "lng",
+
+		// methods
+		"buffer",
+		"distance",
+		"distanceGeodesic",
+		"KNN",
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (p Point) buffer(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, fmt.Errorf("not yet implemented: buffer")
+}
+
+func (p Point) distance(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var p2 Point
+	if err := starlark.UnpackArgs("distance", args, kwargs, "p2", &p2); err != nil {
+		return nil, err
+	}
+
+	d := planar.Distance(orb.Point(p), orb.Point(p2))
+	return starlark.Float(d), nil
+}
+
+func (p Point) distanceGeodesic(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var p2 Point
+	if err := starlark.UnpackArgs("distanceGeodesic", args, kwargs, "p2", &p2); err != nil {
+		return nil, err
+	}
+
+	d := geo.Distance(orb.Point(p), orb.Point(p2))
+	return starlark.Float(d), nil
+}
+
+func (p Point) knn(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, fmt.Errorf("not yet implemented: knn")
+}
+
+// Line is the starlark geographic line type
+type Line struct {
+}
+
+// Polygon is the starlark geographic polygon type
+type Polygon struct {
+}
+
+type builtinMethod func(fnname string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)
+
+func addClosure(name string, recv starlark.Value, method builtinMethod) (*starlark.Builtin, error) {
+	// Allocate a closure over 'method'.
+	impl := func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		return method(b.Name(), b.Receiver(), args, kwargs)
+	}
+	return starlark.NewBuiltin(name, impl).BindReceiver(recv), nil
+}
+
+func floatHash(f float64) (uint32, error) {
+	// Equal float and int values must yield the same hash.
+	if isFinite(f) {
+		return finiteFloatToInt(f).Hash()
+	}
+	return 1618033, nil // NaN, +/-Inf
+}
+
+// isFinite reports whether f represents a finite rational value.
+// It is equivalent to !math.IsNan(f) && !math.IsInf(f, 0).
+func isFinite(f float64) bool {
+	return math.Abs(f) <= math.MaxFloat64
+}
+
+// finiteFloatToInt converts f to an Int, truncating towards zero.
+// f must be finite.
+func finiteFloatToInt(f float64) starlark.Int {
+	var i big.Int
+	if math.MinInt64 <= f && f <= math.MaxInt64 {
+		// small values
+		i.SetInt64(int64(f))
+	} else {
+		rat := new(big.Rat).SetFloat64(f)
+		if rat == nil {
+			panic(f) // non-finite
+		}
+		i.Div(rat.Num(), rat.Denom())
+	}
+	return starlark.MakeInt(int(i.Int64()))
+}
+
+func float64FromNumericValue(n starlark.Value) (float64, error) {
+	switch n.Type() {
+	case "int":
+		i, ok := n.(starlark.Int).Int64()
+		if !ok {
+			return 0, fmt.Errorf("invalid int")
+		}
+		return float64(i), nil
+	case "float":
+		return float64(n.(starlark.Float)), nil
+	default:
+		return 0, fmt.Errorf("invalid type '%s' expected int or float", n.Type())
+	}
 }

--- a/geo/geo.go
+++ b/geo/geo.go
@@ -1,0 +1,28 @@
+package geo
+
+import (
+	"sync"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// ModuleName defines the expected name for this Module when used
+// in starlark's load() function, eg: load('geo.star', 'geo')
+const ModuleName = "geo.star"
+
+var (
+	once      sync.Once
+	geoModule starlark.StringDict
+)
+
+// LoadModule loads the geo module.
+// It is concurrency-safe and idempotent.
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		geoModule = starlark.StringDict{
+			"geo": starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{}),
+		}
+	})
+	return geoModule, nil
+}

--- a/geo/geo_test.go
+++ b/geo/geo_test.go
@@ -1,0 +1,39 @@
+package geo
+
+import (
+	"fmt"
+	"testing"
+
+	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
+)
+
+func init() {
+	resolve.AllowFloat = true
+}
+
+func TestFile(t *testing.T) {
+	thread := &starlark.Thread{Load: newLoader()}
+	starlarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	return func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+		switch module {
+		case ModuleName:
+			return LoadModule()
+		case "assert.star":
+			return starlarktest.LoadAssertModule()
+		}
+
+		return nil, fmt.Errorf("invalid module")
+	}
+}

--- a/geo/geojson.go
+++ b/geo/geojson.go
@@ -1,0 +1,86 @@
+package geo
+
+import (
+	"fmt"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geojson"
+	"github.com/qri-io/starlib/util"
+	"go.starlark.net/starlark"
+)
+
+func parseGeoJSON(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+	var (
+		data      starlark.Value
+		dataBytes []byte
+		fc        *geojson.FeatureCollection
+	)
+	v = starlark.None
+
+	if err = starlark.UnpackArgs("parseGeoJSON", args, kwargs, "data", &data); err != nil {
+		return
+	}
+
+	switch val := data.(type) {
+	case starlark.String:
+		dataBytes = []byte(val)
+	default:
+		err = fmt.Errorf("parseGeoJSON only supports parsing string values")
+		return
+	}
+
+	if fc, err = geojson.UnmarshalFeatureCollection(dataBytes); err != nil {
+		return
+	}
+
+	geoms := make([]starlark.Value, len(fc.Features))
+	properties := make([]starlark.Value, len(fc.Features))
+	for i, feat := range fc.Features {
+		if geoms[i], err = geomFromOrbGeom(feat.Geometry); err != nil {
+			return
+		}
+		if properties[i], err = dictFromGeoJSONProperties(feat.Properties); err != nil {
+			return
+		}
+	}
+
+	return starlark.Tuple([]starlark.Value{
+		starlark.NewList(geoms),
+		starlark.NewList(properties),
+	}), nil
+}
+
+func geomFromOrbGeom(orbGeom orb.Geometry) (starlark.Value, error) {
+	switch geom := orbGeom.(type) {
+	case orb.Point:
+		return Point(geom), nil
+	case orb.LineString:
+		line := make(Line, len(geom))
+		for i, pt := range geom {
+			line[i] = Point(pt)
+		}
+		return line, nil
+	case orb.Ring:
+		line := make(Line, len(geom))
+		for i, pt := range geom {
+			line[i] = Point(pt)
+		}
+		return line, nil
+	case orb.Polygon:
+		poly := make(Polygon, len(geom))
+		for i, r := range geom {
+			line := make(Line, len(r))
+			for j, pt := range r {
+				line[j] = Point(pt)
+			}
+			poly[i] = line
+		}
+		return poly, nil
+	default:
+		return starlark.None, fmt.Errorf("unrecognized geoJSON type: %s", orbGeom.GeoJSONType())
+	}
+}
+
+func dictFromGeoJSONProperties(props geojson.Properties) (starlark.Value, error) {
+	return util.Marshal(map[string]interface{}(props))
+}

--- a/geo/geojson.go
+++ b/geo/geojson.go
@@ -25,7 +25,7 @@ func parseGeoJSON(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tu
 	case starlark.String:
 		dataBytes = []byte(val)
 	default:
-		err = fmt.Errorf("parseGeoJSON only supports parsing string values")
+		err = fmt.Errorf("parseGeoJSON: invalid argument type, expected string")
 		return
 	}
 

--- a/geo/line.go
+++ b/geo/line.go
@@ -13,7 +13,6 @@ import (
 
 func newLine(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
 	var points *starlark.List
-	v = starlark.None
 
 	if err = starlark.UnpackArgs("Line", args, kwargs, "points", &points); err != nil {
 		return

--- a/geo/line.go
+++ b/geo/line.go
@@ -1,0 +1,210 @@
+package geo
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geo"
+	"github.com/paulmach/orb/planar"
+	"go.starlark.net/starlark"
+)
+
+func newLine(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+	var points *starlark.List
+	v = starlark.None
+
+	if err = starlark.UnpackArgs("Line", args, kwargs, "points", &points); err != nil {
+		return
+	}
+
+	return lineFromList(points)
+}
+
+func lineFromList(points *starlark.List) (line Line, err error) {
+	var (
+		v        starlark.Value
+		lat, lng float64
+		i        int
+	)
+
+	line = make(Line, points.Len())
+	iter := points.Iterate()
+	defer iter.Done()
+
+	for iter.Next(&v) {
+		switch pt := v.(type) {
+		case Point:
+			line[i] = pt
+		case *starlark.List:
+			if pt.Len() != 2 {
+				err = fmt.Errorf("wrong number elements for point. expected 2, got: %d", pt.Len())
+			}
+			if lat, err = float64FromNumericValue(pt.Index(0)); err != nil {
+				return
+			}
+			if lng, err = float64FromNumericValue(pt.Index(1)); err != nil {
+				return
+			}
+			line[i] = Point{lat, lng}
+		default:
+			err = fmt.Errorf("invalid type '%s' to create line", pt.Type())
+			return
+		}
+		i++
+	}
+
+	return
+}
+
+// Line is the starlark geographic line type
+type Line []Point
+
+// assert line is a starlark value
+var _ starlark.Value = (*Line)(nil)
+
+// String implements the starlark.Value interface
+func (l Line) String() string {
+	w := strings.Builder{}
+	w.WriteRune('[')
+	for _, p := range l {
+		w.WriteString(p.String() + " ")
+	}
+	w.WriteRune(']')
+	return w.String()
+}
+
+// Type implements the starlark.Value interface
+func (l Line) Type() string { return "Line" }
+
+// Freeze implements the starlark.Value interface, line is immutable
+func (l Line) Freeze() {}
+
+// Truth implements the starlark.Value interface
+func (l Line) Truth() starlark.Bool {
+	return len(l) > 0
+}
+
+// Hash implements the starlark.Value interface
+func (l Line) Hash() (h uint32, err error) {
+	var hash uint32
+	for _, p := range l {
+		if hash, err = p.Hash(); err != nil {
+			return
+		}
+
+		// TODO (b5): this is bad, unique values will report as non-unique. fix
+		h += hash
+	}
+	return
+}
+
+// IsClosed checks that first & last points on the line are equal
+func (l Line) IsClosed() bool {
+	if len(l) == 0 {
+		return false
+	}
+	a := l[0]
+	o := l[len(l)-1]
+	return a[0] == o[0] && a[1] == o[1]
+}
+
+type lineIterator struct {
+	idx  int
+	line Line
+}
+
+// If the iterator is exhausted, Next returns false.
+// Otherwise it sets *p to the current element of the sequence,
+// advances the iterator, and returns true.
+func (li *lineIterator) Next(p *starlark.Value) bool {
+	if li.idx == len(li.line) {
+		return false
+	}
+
+	*p = li.line[li.idx]
+	li.idx++
+	return true
+}
+
+// Done is a no-op
+// TODO (b5): this is supposed to be a no-op. right?
+func (li *lineIterator) Done() {}
+
+// Iterate implements the starlark iterator interface
+func (l Line) Iterate() starlark.Iterator {
+	return &lineIterator{line: l}
+}
+
+// Index implements the starlark indexable interface
+func (l Line) Index(i int) starlark.Value {
+	return l[i]
+}
+
+// Len implements the starlark indexable interface
+func (l Line) Len() int {
+	return len(l)
+}
+
+// func Slice(start, end, step int) starlark.Value {
+// }
+
+// Attr gets an attribute of a line
+func (l Line) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "buffer":
+		return addClosure("buffer", l, l.buffer)
+	case "length":
+		return addClosure("length", l, l.length)
+	case "lengthGeodesic":
+		return addClosure("lengthGeodesic", l, l.lengthGeodesic)
+	default:
+		// attr does not exist
+		return nil, nil
+	}
+}
+
+// AttrNames returns all possible attribute names
+func (l Line) AttrNames() []string {
+	names := []string{
+		// methods
+		"buffer",
+		"length",
+		"lengthGeodesic",
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (l Line) buffer(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, fmt.Errorf("not yet implemented: buffer")
+}
+
+func (l Line) length(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	length := planar.Length(l.OrbLineString())
+	return starlark.Float(length), nil
+}
+
+func (l Line) lengthGeodesic(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	length := geo.Length(l.OrbLineString())
+	return starlark.Float(length), nil
+}
+
+// OrbLineString converts line to a orb.LineString
+func (l Line) OrbLineString() orb.LineString {
+	pts := make([]orb.Point, len(l))
+	for i, pt := range l {
+		pts[i] = orb.Point(pt)
+	}
+	return orb.LineString(pts)
+}
+
+// OrbRing converts line to a orb.Ring
+func (l Line) OrbRing() orb.Ring {
+	pts := make([]orb.Point, len(l))
+	for i, pt := range l {
+		pts[i] = orb.Point(pt)
+	}
+	return orb.Ring(pts)
+}

--- a/geo/multi_polygon.go
+++ b/geo/multi_polygon.go
@@ -13,7 +13,6 @@ func newMultiPolygon(thread *starlark.Thread, _ *starlark.Builtin, args starlark
 		polygons *starlark.List
 		x        starlark.Value
 	)
-	v = starlark.None
 
 	if err = starlark.UnpackArgs("MultiPolygon", args, kwargs, "polygons", &polygons); err != nil {
 		return

--- a/geo/multi_polygon.go
+++ b/geo/multi_polygon.go
@@ -1,0 +1,148 @@
+package geo
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/paulmach/orb"
+	"go.starlark.net/starlark"
+)
+
+func newMultiPolygon(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+	var (
+		polygons *starlark.List
+		x        starlark.Value
+	)
+	v = starlark.None
+
+	if err = starlark.UnpackArgs("MultiPolygon", args, kwargs, "polygons", &polygons); err != nil {
+		return
+	}
+
+	i := 0
+	p := make(MultiPolygon, polygons.Len())
+	iter := polygons.Iterate()
+	defer iter.Done()
+
+	for iter.Next(&x) {
+		switch geom := x.(type) {
+		case Polygon:
+			p[i] = geom
+		default:
+			err = fmt.Errorf("invalid type for creating MultiPolygon: %s", x.Type())
+			return
+		}
+		i++
+	}
+	return p, nil
+}
+
+// MultiPolygon is the starlark geographic collection-of-polygons type
+type MultiPolygon []Polygon
+
+// assert polygon is a starlark value
+var _ starlark.Value = (*MultiPolygon)(nil)
+
+// String implements the starlark.Value interface
+func (p MultiPolygon) String() string {
+	// TODO (b5): finish this
+	return fmt.Sprintf("multi polygon %d polygons", len(p))
+	// w := strings.Builder{}
+	// w.WriteRune('[')
+	// for _, p := range p {
+	// 	w.WriteString(p.String() + " ")
+	// }
+	// w.WriteRune(']')
+	// return w.String()
+}
+
+// Type implements the starlark.Value interface
+func (p MultiPolygon) Type() string { return "MultiPolygon" }
+
+// Freeze implements the starlark.Value interface, polygon is immutable
+func (p MultiPolygon) Freeze() {}
+
+// Truth implements the starlark.Value interface
+func (p MultiPolygon) Truth() starlark.Bool {
+	return len(p) > 0
+}
+
+// Hash implements the starlark.Value interface
+func (p MultiPolygon) Hash() (h uint32, err error) {
+	var hash uint32
+	for _, poly := range p {
+		if hash, err = poly.Hash(); err != nil {
+			return
+		}
+		// TODO (b5): this is bad, unique values will report as non-unique. fix
+		h += hash
+	}
+	return
+}
+
+// OrbMultiPolygon formats polygon as an orb.MultiPolygon
+func (p MultiPolygon) OrbMultiPolygon() orb.MultiPolygon {
+	polys := make([]orb.Polygon, len(p))
+	for i, l := range p {
+		polys[i] = l.OrbPolygon()
+	}
+	return orb.MultiPolygon(polys)
+}
+
+type multiPolygonIterator struct {
+	idx     int
+	polygon MultiPolygon
+}
+
+// If the iterator is exhausted, Next returns false.
+// Otherwise it sets *p to the current element of the sequence,
+// advances the iterator, and returns true.
+func (li *multiPolygonIterator) Next(p *starlark.Value) bool {
+	if li.idx == len(li.polygon) {
+		return false
+	}
+
+	*p = li.polygon[li.idx]
+	li.idx++
+	return true
+}
+
+// Done is a no-op
+// TODO (b5): this is supposed to be a no-op. right?
+func (li *multiPolygonIterator) Done() {}
+
+// Iterate implements the starlark iterator interface
+func (p MultiPolygon) Iterate() starlark.Iterator {
+	return &multiPolygonIterator{polygon: p}
+}
+
+// Index implements the starlark indexable interface
+func (p MultiPolygon) Index(i int) starlark.Value {
+	return p[i]
+}
+
+// Len implements the starlark indexable interface
+func (p MultiPolygon) Len() int {
+	return len(p)
+}
+
+// func Slice(start, end, step int) starlark.Value {
+// }
+
+// Attr gets an attribute of a polygon
+func (p MultiPolygon) Attr(name string) (starlark.Value, error) {
+	switch name {
+	default:
+		// attr does not exist
+		return nil, nil
+	}
+}
+
+// AttrNames returns all possible attribute names
+func (p MultiPolygon) AttrNames() []string {
+	names := []string{
+		// methods
+	}
+	sort.Strings(names)
+	return names
+}

--- a/geo/point.go
+++ b/geo/point.go
@@ -15,7 +15,6 @@ func newPoint(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple,
 		x, y     starlark.Value
 		lat, lng float64
 	)
-	v = starlark.None
 
 	if err = starlark.UnpackArgs("Point", args, kwargs, "x", &x, "y", &y); err != nil {
 		return

--- a/geo/point.go
+++ b/geo/point.go
@@ -1,0 +1,125 @@
+package geo
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/paulmach/orb"
+	"github.com/paulmach/orb/geo"
+	"github.com/paulmach/orb/planar"
+	"go.starlark.net/starlark"
+)
+
+func newPoint(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+	var (
+		x, y     starlark.Value
+		lat, lng float64
+	)
+	v = starlark.None
+
+	if err = starlark.UnpackArgs("Point", args, kwargs, "x", &x, "y", &y); err != nil {
+		return
+	}
+
+	if lat, err = float64FromNumericValue(x); err != nil {
+		return
+	}
+	if lng, err = float64FromNumericValue(y); err != nil {
+		return
+	}
+
+	return Point{lat, lng}, nil
+}
+
+// Point is the starlark geographic point type
+type Point [2]float64
+
+// assert point is a starlark value
+var _ starlark.Value = (*Point)(nil)
+
+// String implements the starlark.Value interface
+func (p Point) String() string { return fmt.Sprintf("(%f,%f)", p[0], p[1]) }
+
+// Type implements the starlark.Value interface
+func (p Point) Type() string { return "Point" }
+
+// Freeze implements the starlark.Value interface, point is immutable
+func (p Point) Freeze() {}
+
+// Truth implements the starlark.Value interface
+func (p Point) Truth() starlark.Bool {
+	return starlark.Bool(p[0] != 0 && p[1] != 0)
+}
+
+// Hash implements the starlark.Value interface
+func (p Point) Hash() (uint32, error) {
+	x, _ := floatHash(p[0])
+	y, _ := floatHash(p[1])
+	// TODO (b5): this is bad. fix
+	return x - y, nil
+}
+
+// Attr gets an attribute of point
+func (p Point) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "x", "lat":
+		return starlark.Float(p[0]), nil
+	case "y", "lng":
+		return starlark.Float(p[1]), nil
+	case "buffer":
+		return addClosure("buffer", p, p.buffer)
+	case "distance":
+		return addClosure("distance", p, p.distance)
+	case "distanceGeodesic":
+		return addClosure("distanceGeodesic", p, p.distanceGeodesic)
+	case "KNN":
+		return addClosure("KNN", p, p.knn)
+	default:
+		// attr does not exist
+		return nil, nil
+	}
+}
+
+// AttrNames returns all possible attribute names
+func (p Point) AttrNames() []string {
+	names := []string{
+		// attributes
+		"x", "y", "lat", "lng",
+
+		// methods
+		"buffer",
+		"distance",
+		"distanceGeodesic",
+		"KNN",
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (p Point) buffer(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, fmt.Errorf("not yet implemented: buffer")
+}
+
+func (p Point) distance(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var p2 Point
+	if err := starlark.UnpackArgs("distance", args, kwargs, "p2", &p2); err != nil {
+		return nil, err
+	}
+
+	d := planar.Distance(orb.Point(p), orb.Point(p2))
+	return starlark.Float(d), nil
+}
+
+func (p Point) distanceGeodesic(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var p2 Point
+	if err := starlark.UnpackArgs("distanceGeodesic", args, kwargs, "p2", &p2); err != nil {
+		return nil, err
+	}
+
+	d := geo.Distance(orb.Point(p), orb.Point(p2))
+	return starlark.Float(d), nil
+}
+
+func (p Point) knn(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, fmt.Errorf("not yet implemented: knn")
+}

--- a/geo/polygon.go
+++ b/geo/polygon.go
@@ -13,7 +13,6 @@ func newPolygon(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tupl
 	var (
 		rings *starlark.List
 	)
-	v = starlark.None
 
 	if err = starlark.UnpackArgs("Polygon", args, kwargs, "rings", &rings); err != nil {
 		return

--- a/geo/polygon.go
+++ b/geo/polygon.go
@@ -1,0 +1,163 @@
+package geo
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/paulmach/orb"
+
+	"go.starlark.net/starlark"
+)
+
+func newPolygon(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (v starlark.Value, err error) {
+	var (
+		rings *starlark.List
+	)
+	v = starlark.None
+
+	if err = starlark.UnpackArgs("Polygon", args, kwargs, "rings", &rings); err != nil {
+		return
+	}
+
+	i := 0
+	p := make(Polygon, rings.Len())
+	iter := rings.Iterate()
+	defer iter.Done()
+	var x starlark.Value
+
+	for iter.Next(&x) {
+		switch l := x.(type) {
+		case Line:
+			if !l.IsClosed() {
+				err = fmt.Errorf("line %d is not closed", i)
+				return
+			}
+			p[i] = l
+		case *starlark.List:
+			line, err := lineFromList(l)
+			if err != nil {
+				return v, err
+			}
+			if !line.IsClosed() {
+				return v, fmt.Errorf("line %d is not closed", i)
+			}
+			p[i] = line
+		default:
+			err = fmt.Errorf("invalid type for creating polygon: %s", x.Type())
+			return
+		}
+		i++
+	}
+	return p, nil
+}
+
+// Polygon is the starlark geographic polygon type
+type Polygon []Line
+
+// assert polygon is a starlark value
+var _ starlark.Value = (*Polygon)(nil)
+
+// String implements the starlark.Value interface
+func (p Polygon) String() string {
+	// TODO (b5): finish this
+	return fmt.Sprintf("polygon %d rings", len(p))
+	// w := strings.Builder{}
+	// w.WriteRune('[')
+	// for _, p := range p {
+	// 	w.WriteString(p.String() + " ")
+	// }
+	// w.WriteRune(']')
+	// return w.String()
+}
+
+// Type implements the starlark.Value interface
+func (p Polygon) Type() string { return "Polygon" }
+
+// Freeze implements the starlark.Value interface, polygon is immutable
+func (p Polygon) Freeze() {}
+
+// Truth implements the starlark.Value interface
+func (p Polygon) Truth() starlark.Bool {
+	return len(p) > 0
+}
+
+// Hash implements the starlark.Value interface
+func (p Polygon) Hash() (h uint32, err error) {
+	var hash uint32
+	for _, l := range p {
+		if hash, err = l.Hash(); err != nil {
+			return
+		}
+
+		// TODO (b5): this is bad, unique values will report as non-unique. fix
+		h += hash
+	}
+	return
+}
+
+// OrbPolygon formats polygon as an orb.Polygon
+func (p Polygon) OrbPolygon() orb.Polygon {
+	ring := make([]orb.Ring, len(p))
+	for i, l := range p {
+		ring[i] = l.OrbRing()
+	}
+	return orb.Polygon(ring)
+}
+
+type polygonIterator struct {
+	idx     int
+	polygon Polygon
+}
+
+// If the iterator is exhausted, Next returns false.
+// Otherwise it sets *p to the current element of the sequence,
+// advances the iterator, and returns true.
+func (li *polygonIterator) Next(p *starlark.Value) bool {
+	if li.idx == len(li.polygon) {
+		return false
+	}
+
+	*p = li.polygon[li.idx]
+	li.idx++
+	return true
+}
+
+// Done is a no-op
+// TODO (b5): this is supposed to be a no-op. right?
+func (li *polygonIterator) Done() {}
+
+// Iterate implements the starlark iterator interface
+func (p Polygon) Iterate() starlark.Iterator {
+	return &polygonIterator{polygon: p}
+}
+
+// Index implements the starlark indexable interface
+func (p Polygon) Index(i int) starlark.Value {
+	return p[i]
+}
+
+// Len implements the starlark indexable interface
+func (p Polygon) Len() int {
+	return len(p)
+}
+
+// func Slice(start, end, step int) starlark.Value {
+// }
+
+// Attr gets an attribute of a polygon
+func (p Polygon) Attr(name string) (starlark.Value, error) {
+	switch name {
+	default:
+		// attr does not exist
+		return nil, nil
+	}
+}
+
+// AttrNames returns all possible attribute names
+func (p Polygon) AttrNames() []string {
+	names := []string{
+		// methods
+	}
+	sort.Strings(names)
+	return names
+}

--- a/geo/template.html
+++ b/geo/template.html
@@ -1,0 +1,56 @@
+{{- define "mdFn" }}
+#### `{{ .Signature }}`
+{{- if ne .Description "" }}
+{{ .Description }}
+{{- end -}}
+{{- if gt (len .Params) 0 }}
+**parameters:**
+| name | type | description |
+|------|------|-------------|
+{{ range .Params -}}
+| `{{ .Name }}` | `{{ .Type }}` | {{ .Description }} |
+{{ end -}}
+{{- end -}}
+{{- end -}}
+
+{{- range . -}}
+# {{ .Name }}
+{{ if ne .Description "" }}{{ .Description }}{{ end }}
+{{- if gt (len .Functions) 0 }}
+
+## Functions
+{{ range .Functions -}}
+{{ template "mdFn" . }}
+{{ end -}}
+{{- end }}
+{{ if gt (len .Types) 0 }}
+## Types
+
+{{ range .Types -}}
+### `{{ .Name }}`
+{{ if ne .Description "" }}{{ .Description }}{{ end -}}
+{{ if gt (len .Fields) 0 }}
+**Fields**
+| name | type | description |
+|------|------|-------------|
+{{ range .Fields -}}
+| {{ .Name }} | {{ .Type }} | {{ .Description }} |
+{{ end -}}
+{{ end -}}
+{{ if gt (len .Methods) 0 }}
+**Methods**
+{{- range .Methods -}}
+{{ template "mdFn" . }}
+{{ end -}}
+{{- if gt (len .Operators) 0 }}
+**Operators**
+| operator | description |
+|----------|-------------|
+{{ range .Operators -}}
+	| {{ .Opr }} | {{ .Description }} |
+{{ end }}
+{{ end }}
+{{ end }}
+{{- end -}}
+{{- end -}}
+{{ end }}

--- a/geo/testdata/test.star
+++ b/geo/testdata/test.star
@@ -1,15 +1,102 @@
 load('geo.star', 'geo')
 load('assert.star','assert')
 
-p1 = geo.point(-44.34, 33)
+p1 = geo.Point(-44.34, 33)
 
 assert.eq(p1.x, -44.34)
 assert.eq(p1.lat, -44.34)
 assert.eq(p1.y, 33)
 assert.eq(p1.lng, 33)
 
-p2 = geo.point(-44, 33)
+p2 = geo.Point(-44, 33)
 assert.eq(p1.distanceGeodesic(p2), 31742.52939277697)
 
-planar_d = geo.point(1,1).distance(geo.point(2,1))
+planar_d = geo.Point(1,1).distance(geo.Point(2,1))
 assert.eq(planar_d, 1)
+
+line = geo.Line([[1,2], geo.Point(2,2)])
+
+assert.eq(line.length(), 1)
+assert.eq(line.lengthGeodesic(), 111251.67796723428)
+
+p = geo.Polygon([
+        # Outer boundary
+        [
+          [-93.515625, 54.16243396806779],
+          [-99.49218749999999,42.5530802889558],
+          [-72.0703125, 32.24997445586331],
+          [-72.0703125, 43.83452678223682],
+          [-72.0703125, 54.36775852406841],
+          [-80.85937499999999, 57.326521225217064],
+          [-93.515625, 54.16243396806779],
+        ],
+
+        # Hole in Polygon
+        [
+          [-87.1875, 49.61070993807422],
+          [-87.890625, 44.59046718130883],
+          [-81.2109375, 43.83452678223682],
+          [-80.5078125, 48.22467264956519],
+          [-87.1875, 49.61070993807422],
+        ],
+])
+
+
+p3 = geo.Point(-65.390625,48.45835188280866)
+p4 = geo.Point(-93.5,53.1)
+
+poly1 = geo.Polygon([
+      [
+        [-93.515625, 54.16243396806779],
+        [-99.49218749999999, 42.5530802889558],
+        [-72.0703125, 32.24997445586331],
+        [-72.0703125, 43.83452678223682],
+        [-72.0703125, 54.36775852406841],
+        [-80.85937499999999, 57.326521225217064],
+        [-93.515625, 54.16243396806779],
+      ]
+ ])
+
+assert.eq(geo.within(p3, poly1), False)
+assert.eq(geo.within(p4, poly1), True)
+
+
+geoJSONString = '''{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "ufo_sightings": 20,
+        "population": 40
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -103.0078125,
+          38.272688535980976
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "ufo_sightings": 100,
+        "population": 2
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -87.1875,
+          47.989921667414194
+        ]
+      }
+    }
+  ]
+}'''
+
+geoms, properties = geo.parseGeoJSON(geoJSONString)
+
+assert.eq(geoms[0].lat,-103.0078125)
+assert.eq(geoms[0].lng, 38.272688535980976)
+assert.eq(properties[1]["ufo_sightings"], 100)

--- a/geo/testdata/test.star
+++ b/geo/testdata/test.star
@@ -1,0 +1,15 @@
+load('geo.star', 'geo')
+load('assert.star','assert')
+
+p1 = geo.point(-44.34, 33)
+
+assert.eq(p1.x, -44.34)
+assert.eq(p1.lat, -44.34)
+assert.eq(p1.y, 33)
+assert.eq(p1.lng, 33)
+
+p2 = geo.point(-44, 33)
+assert.eq(p1.distanceGeodesic(p2), 31742.52939277697)
+
+planar_d = geo.point(1,1).distance(geo.point(2,1))
+assert.eq(planar_d, 1)

--- a/geo/testdata/test.star
+++ b/geo/testdata/test.star
@@ -60,6 +60,8 @@ poly1 = geo.Polygon([
 assert.eq(geo.within(p3, poly1), False)
 assert.eq(geo.within(p4, poly1), True)
 
+combine_poly = geo.MultiPolygon([poly1, p])
+
 
 geoJSONString = '''{
   "type": "FeatureCollection",

--- a/makefile
+++ b/makefile
@@ -7,7 +7,8 @@ github.com/mohae/deepcopy \
 github.com/qri-io/dataset \
 golang.org/x/net/html \
 go.starlark.net/starlark \
-github.com/qri-io/dataset/dsio/replacecr
+github.com/qri-io/dataset/dsio/replacecr \
+github.com/paulmach/orb
 endef
 
 default: install-deps

--- a/starlib.go
+++ b/starlib.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/qri-io/starlib/encoding/base64"
 	"github.com/qri-io/starlib/encoding/csv"
+	"github.com/qri-io/starlib/geo"
 	"github.com/qri-io/starlib/html"
 	"github.com/qri-io/starlib/http"
 	"github.com/qri-io/starlib/re"
@@ -15,7 +16,7 @@ import (
 )
 
 // Version is the current semver for the entire starlib library
-const Version = "0.1.0"
+const Version = "0.2.0"
 
 // Loader presents the starlib library as a loader
 func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, err error) {
@@ -36,6 +37,8 @@ func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, e
 		return base64.LoadModule()
 	case csv.ModuleName:
 		return csv.LoadModule()
+	case geo.ModuleName:
+		return geo.LoadModule()
 	}
 
 	return nil, fmt.Errorf("invalid module")


### PR DESCRIPTION
This PR take a very large bite out of [RFC0015](https://github.com/qri-io/rfcs/blob/master/text/0000-add-geo-processing-abilities-to-skylark.md). I keep working on datasets, and keep needing geo functions. Having played with this branch in it's current state I'm confident there are _many_ uses for this module 😄. That, and lots of the people we're working with right now would use this package if it existed.

** **
### Example

For this PR I focused on getting the example transform script from the RFC to work. here's what the adapted code ended up looking like:
```python
load("http.star", "http")
load("geo.star", "geo")

def download(ctx):
  # Download list of 311 complaints, currently capped to 10000 responses for testing purposes
  complaints = http.get("https://data.cityofnewyork.us/resource/fhrw-4uyv.json?$offset=0&$limit=10000")
  # Download the New York Borough Boundaries
  boros = http.get("http://data.beta.nyc//dataset/68c0332f-c3bb-4a78-a0c1-32af515892d6/resource/7c164faa-4458-4ff2-9ef0-09db00b509ef/download/42c737fd496f4d6683bba25fb0e86e1dnycboroughboundaries.geojson")

  return {
    "complaints" : complaints.json(),
    # send boros over as a JSON string, parseGeoJSON will do the decoding
    "boros": boros.text(),
  }


def transform(ds, ctx):
  complaints = ctx.download["complaints"]
  boundaries, properties = geo.parseGeoJSON(ctx.download["boros"])

  # bouroughs data specifies a number of polygons for each borough,
  # combine them all into MultiPolygons, one for each borough
  boro_names = [ boro['borough'] for boro in properties]
  geoms = reduce(append_polygon, zip(boro_names, boundaries), {})
  geoms = [geo.MultiPolygon(geoms[x]) for x in geoms]
  boro_names = list(set(boro_names))

  # dict of complaint-counts, keyed by borough name
  boro_counts = dict(zip(boro_names, [0]*len(boro_names)))
  
  for complaint in complaints:
    # only use complaints that have lat & lng values
    if 'latitude' in complaint and 'longitude' in complaint:
      point = geo.Point(float(complaint['longitude']), float(complaint['latitude']))
      for boro_name, geom in zip(boro_names, geoms):
        if geo.within(point, geom):
          boro_counts[boro_name] += 1
  
  ds.set_body(boro_counts)


def append_polygon(acc, prop):
  polys = acc.get(prop[0], [])
  polys.append(prop[1])
  acc[prop[0]] = polys
  return acc

def reduce(fn, l, v):
	for _, el in enumerate(l):
		v = fn(v, el)
	return v
```

If you pull this branch & rebuild qri, save the above as `transform.star`, and create a new file: `dataset.yaml`:
```yaml
name: nyc_311_complaints_by_boro
transform:
  scriptpath: ./transform.star
```
you should get something like this:
```shell
$ qri save --file dataset.yaml
📡 running download...
🤖  running transform...
✅ transform complete
dataset saved: b5/nyc_311_complaints_by_boro@QmSyDX5LYTiwQi861F5NAwdHrrnd1iRGsoEvCyzQMUyZ4W/ipfs/QmRRFD7Y4zRpKpE3C4WGdQdmqwznXuQNpDPfbip523TqFC

$ qri body me/nyc_311_complaints_by_boro
{"Staten Island":481,"Queens":2038,"Brooklyn":2857,"Manhattan":1559,"Bronx":1746}
```

** **
### Outstanding Work

This PR doesn't complete the list of tricks outlined in the RFC tho. The following are **missing** from this PR to round out the initial geo RFC:
```
outline: geo
  functions:
    intersects(geom,polygon)
      Similar to within but part of geometry B can lie outside of geometry A 
      and it will still return True
      params:
        geom [point,line,polygon]
          maybe-inner geometry
        polygon [Polygon,MultiPolygon]
          maybe-outer polygon
  types:
    Point
      methods:
        buffer(x int) Polygon
          Generates a buffered region of x units around a point
        KNN()
          Given a target point T and an array of other points, return the K nearest points to T
        greatCircle(p2 point)
          Returns the great circle line segment to point 2
    Line:
      methods:
        buffer(x int) Polygon
          Generates a buffered region of x units around the line
```

Most of the things that are left require doing some actual math (instead of relying on the underlying `orb` package to do it for us). `Point.KNN` should be the easiest to ship next, the package we rely on has a [KNearest function in the quadtree subpackage](https://godoc.org/github.com/paulmach/orb/quadtree#Quadtree.KNearest).

`geo.intersects` is the one I'm most concerned about (doesn't seem to be an easy off-hand solution for this), followed by determining a pattern for `buffer` methods.