### PR TITLE
feat(json): add initial json package

### DIFF
--- a/encoding/csv/csv.go
+++ b/encoding/csv/csv.go
@@ -34,23 +34,6 @@ func LoadModule() (starlark.StringDict, error) {
 	return csvModule, nil
 }
 
-// Module joins http tools to a dataset, allowing dataset
-// to follow along with http requests
-type Module struct {
-}
-
-// Struct returns this module's methods as a starlark Struct
-func (m *Module) Struct() *starlarkstruct.Struct {
-	return starlarkstruct.FromStringDict(starlarkstruct.Default, m.StringDict())
-}
-
-// StringDict returns all module methods in a starlark.StringDict
-func (m *Module) StringDict() starlark.StringDict {
-	return starlark.StringDict{
-		"read_all": starlark.NewBuiltin("read_all", ReadAll),
-	}
-}
-
 // ReadAll gets all values from a csv source
 func ReadAll(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var (

--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -1,0 +1,19 @@
+/*Package json implements a json parser for the starlark programming dialect
+
+  outline: json
+    json provides functions for working with json data
+    path: encoding/json
+    functions:
+      dumps(obj) string
+        serialize obj to a JSON string
+        params:
+          obj object
+            input object
+      loads(source) object
+        read a source JSON string to a starlark object
+        params:
+          source string
+            input string of json data
+
+*/
+package json

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -1,0 +1,76 @@
+package json
+
+import (
+	"encoding/json"
+	"sync"
+
+	"github.com/qri-io/starlib/util"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// ModuleName defines the expected name for this Module when used
+// in starlark's load() function, eg: load('encoding/json.star', 'json')
+const ModuleName = "encoding/json.star"
+
+var (
+	once       sync.Once
+	jsonModule starlark.StringDict
+)
+
+// LoadModule loads the base64 module.
+// It is concurrency-safe and idempotent.
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		jsonModule = starlark.StringDict{
+			"json": starlarkstruct.FromStringDict(starlarkstruct.Default, starlark.StringDict{
+				"loads": starlark.NewBuiltin("loads", Loads),
+				"dumps": starlark.NewBuiltin("dumps", Dumps),
+			}),
+		}
+	})
+	return jsonModule, nil
+}
+
+// Loads gets all values from a json source
+func Loads(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		source starlark.String
+		val    interface{}
+	)
+
+	err := starlark.UnpackArgs("loads", args, kwargs, "source", &source)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal([]byte(source.GoString()), &val); err != nil {
+		return starlark.None, err
+	}
+
+	return util.Marshal(val)
+}
+
+// Dumps serializes a starlark object to a json string
+func Dumps(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		source starlark.Value
+	)
+
+	err := starlark.UnpackArgs("dumps", args, kwargs, "source", &source)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	val, err := util.Unmarshal(source)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	data, err := json.Marshal(val)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	return starlark.String(string(data)), nil
+}

--- a/encoding/json/json_test.go
+++ b/encoding/json/json_test.go
@@ -1,0 +1,40 @@
+package json
+
+import (
+	"fmt"
+	"testing"
+
+	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
+)
+
+func TestFile(t *testing.T) {
+	resolve.AllowFloat = true
+	thread := &starlark.Thread{Load: newLoader()}
+	starlarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
+	if err != nil {
+		if ee, ok := err.(*starlark.EvalError); ok {
+			t.Error(ee.Backtrace())
+		} else {
+			t.Error(err)
+		}
+	}
+}
+
+// load implements the 'load' operation as used in the evaluator tests.
+func newLoader() func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	return func(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+		switch module {
+		case ModuleName:
+			return LoadModule()
+		case "assert.star":
+			return starlarktest.LoadAssertModule()
+		}
+
+		return nil, fmt.Errorf("invalid module")
+	}
+}

--- a/encoding/json/testdata/test.star
+++ b/encoding/json/testdata/test.star
@@ -1,0 +1,14 @@
+
+load('encoding/json.star', 'json')
+load('assert.star', 'assert')
+
+json_string_1 = """[["a","b","c"],
+[1,2,3],
+[4,5,6],
+[7,8,9]
+]
+"""
+
+json_1 = json.loads(json_string_1)
+assert.eq(json_1, [["a","b","c"],[1,2,3],[4,5,6],[7,8,9]])
+assert.eq(json.dumps(json_1), "[[\"a\",\"b\",\"c\"],[1,2,3],[4,5,6],[7,8,9]]")

--- a/starlib.go
+++ b/starlib.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/qri-io/starlib/encoding/base64"
 	"github.com/qri-io/starlib/encoding/csv"
+	"github.com/qri-io/starlib/encoding/json"
 	"github.com/qri-io/starlib/geo"
 	"github.com/qri-io/starlib/html"
 	"github.com/qri-io/starlib/http"
@@ -16,7 +17,7 @@ import (
 )
 
 // Version is the current semver for the entire starlib library
-const Version = "0.2.0"
+const Version = "0.2.1-dev"
 
 // Loader presents the starlib library as a loader
 func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, err error) {
@@ -37,9 +38,11 @@ func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, e
 		return base64.LoadModule()
 	case csv.ModuleName:
 		return csv.LoadModule()
+	case json.ModuleName:
+		return json.LoadModule()
 	case geo.ModuleName:
 		return geo.LoadModule()
 	}
 
-	return nil, fmt.Errorf("invalid module")
+	return nil, fmt.Errorf("invalid module '%s'", module)
 }


### PR DESCRIPTION
get started nice & easy with an API that matches python's `json` package: https://docs.python.org/3/library/json.html

closes #19 

** **
outline:
# json
json provides functions for working with json data

## Functions

#### `dumps(obj) string`
serialize obj to a JSON string
**parameters:**

| name | type | description |
|------|------|-------------|
| `obj` | `object` | input object |


#### `loads(source) object`
read a source JSON string to a starlark object
**parameters:**

| name | type | description |
|------|------|-------------|
| `source` | `string` | input string of json data |