### PR TITLE
feat(starlib): util.Marshal extended compatibility and tests

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -119,8 +119,26 @@ func Marshal(data interface{}) (v starlark.Value, err error) {
 		v = starlark.String(x)
 	case int:
 		v = starlark.MakeInt(x)
+	case int8:
+		v = starlark.MakeInt(int(x))
+	case int16:
+		v = starlark.MakeInt(int(x))
+	case int32:
+		v = starlark.MakeInt(int(x))
 	case int64:
-		v = starlark.MakeInt64(int64(x))
+		v = starlark.MakeInt64(x)
+	case uint:
+		v = starlark.MakeUint(x)
+	case uint8:
+		v = starlark.MakeUint(uint(x))
+	case uint16:
+		v = starlark.MakeUint(uint(x))
+	case uint32:
+		v = starlark.MakeUint(uint(x))
+	case uint64:
+		v = starlark.MakeUint64(x)
+	case float32:
+		v = starlark.Float(float64(x))
 	case float64:
 		v = starlark.Float(x)
 	case []interface{}:
@@ -132,6 +150,25 @@ func Marshal(data interface{}) (v starlark.Value, err error) {
 			}
 		}
 		v = starlark.NewList(elems)
+	case map[interface{}]interface{}:
+		dict := &starlark.Dict{}
+		var elem starlark.Value
+		for ki, val := range x {
+			var key starlark.Value
+			key, err = Marshal(ki)
+			if err != nil {
+				return
+			}
+
+			elem, err = Marshal(val)
+			if err != nil {
+				return
+			}
+			if err = dict.SetKey(key, elem); err != nil {
+				return
+			}
+		}
+		v = dict
 	case map[string]interface{}:
 		dict := &starlark.Dict{}
 		var elem starlark.Value

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -38,3 +38,65 @@ func TestAsString(t *testing.T) {
 		}
 	}
 }
+
+func TestMarshal(t *testing.T) {
+	expectedStringDict := starlark.NewDict(1)
+	expectedStringDict.SetKey(starlark.String("foo"), starlark.MakeInt(42))
+
+	expectedIntDict := starlark.NewDict(1)
+	expectedIntDict.SetKey(starlark.MakeInt(42*2), starlark.MakeInt(42))
+
+	cases := []struct {
+		in  interface{}
+		got starlark.Value
+		err string
+	}{
+		{nil, starlark.None, ""},
+		{true, starlark.True, ""},
+		{"foo", starlark.String("foo"), ""},
+		{42, starlark.MakeInt(42), ""},
+		{int8(42), starlark.MakeInt(42), ""},
+		{int16(42), starlark.MakeInt(42), ""},
+		{int32(42), starlark.MakeInt(42), ""},
+		{int64(42), starlark.MakeInt(42), ""},
+		{uint(42), starlark.MakeUint(42), ""},
+		{uint8(42), starlark.MakeUint(42), ""},
+		{uint16(42), starlark.MakeUint(42), ""},
+		{uint32(42), starlark.MakeUint(42), ""},
+		{uint64(42), starlark.MakeUint64(42), ""},
+		{float32(42), starlark.Float(42), ""},
+		{42., starlark.Float(42), ""},
+		{[]interface{}{42}, starlark.NewList([]starlark.Value{starlark.MakeInt(42)}), ""},
+		{map[string]interface{}{"foo": 42}, expectedStringDict, ""},
+		{map[interface{}]interface{}{"foo": 42}, expectedStringDict, ""},
+		{map[interface{}]interface{}{42 * 2: 42}, expectedIntDict, ""},
+	}
+
+	for i, c := range cases {
+		got, err := Marshal(c.in)
+		if !(err == nil && c.err == "" || err != nil && err.Error() == c.err) {
+			t.Errorf("case %d error mismatch. expected: '%s', got: '%s'", i, c.err, err)
+			continue
+		}
+
+		if list, ok := c.got.(*starlark.List); ok {
+			if list.String() != got.String() {
+				t.Errorf("case %d. expected: '%s', got: '%s'", i, c.got, got)
+			}
+
+			continue
+		}
+
+		if dict, ok := c.got.(*starlark.Dict); ok {
+			if dict.String() != got.String() {
+				t.Errorf("case %d. expected: '%s', got: '%s'", i, c.got, got)
+			}
+
+			continue
+		}
+
+		if c.got != got {
+			t.Errorf("case %d. expected: '%s', got: '%s'", i, c.got, got)
+		}
+	}
+}


### PR DESCRIPTION
I was working on a `encoding/yaml` module and I found that `util.Marshal` lacks some types support. I added the coverage of this types plus a test for it.

Also I believe that can be useful introduce support for an interface like:
```go
type StarkarkMarshaller interface {
   AsStarlark() starlark.Value
}
```

To allow conversion from any type and not just the standard ones. 