### PR TITLE
feat(time): Add in_location and format methods

### DIFF
--- a/time/doc.go
+++ b/time/doc.go
@@ -29,14 +29,19 @@ package from the go standard library.
           duration == duration = boolean
           duration < duration = booleans
       time
-        fields:
-          year int
-          month int
-          day int
-          hour int
-          minute int
-          second int
-          nanosecond int
+        functions:
+          year() int
+          month() int
+          day() int
+          hour() int
+          minute() int
+          second() int
+          nanosecond() int
+		  in_location(string) time
+		  	get time representing the same instant but in a different location
+		  format(string) string
+		  	textual representation of time formatted according to the provided
+			layout string
         operators:
           time == time = boolean
           time < time = boolean

--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -10,6 +10,8 @@ assert.true(time.time("2012-04-22T13:33:48Z") > time.time("2011-04-22T13:33:48Z"
 t = time.time("2000-01-02T03:04:05Z")
 # TODO- make this a field, not a method
 assert.eq(t.year(), 2000)
+assert.eq(t.in_location("US/Eastern"), time.time("2000-01-01T22:04:05-05:00"))
+assert.eq(t.in_location("US/Eastern").format("3 04 PM"), "10 04 PM")
 
 assert.eq(t - t, time.duration("0s"))
 

--- a/time/time.go
+++ b/time/time.go
@@ -282,13 +282,15 @@ func (t Time) Binary(op syntax.Token, yV starlark.Value, side starlark.Side) (st
 }
 
 var timeMethods = map[string]builtinMethod{
-	"year":       timeyear,
-	"month":      timemonth,
-	"day":        timeday,
-	"hour":       timehour,
-	"minute":     timeminute,
-	"second":     timesecond,
-	"nanosecond": timenanosecond,
+	"year":        timeyear,
+	"month":       timemonth,
+	"day":         timeday,
+	"hour":        timehour,
+	"minute":      timeminute,
+	"second":      timesecond,
+	"nanosecond":  timenanosecond,
+	"in_location": timein,
+	"format":      timeformat,
 }
 
 // TODO - consider using a higher order function to generate these
@@ -325,6 +327,30 @@ func timesecond(fnname string, recV starlark.Value, args starlark.Tuple, kwargs 
 func timenanosecond(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	recv := gotime.Time(recV.(Time))
 	return starlark.MakeInt(recv.Nanosecond()), nil
+}
+
+func timeformat(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x starlark.String
+	if err := starlark.UnpackArgs("location", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+
+	recv := gotime.Time(recV.(Time))
+	return starlark.String(recv.Format(string(x))), nil
+}
+
+func timein(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x starlark.String
+	if err := starlark.UnpackArgs("location", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+	loc, err := gotime.LoadLocation(string(x))
+	if err != nil {
+		return nil, err
+	}
+
+	recv := gotime.Time(recV.(Time))
+	return Time(recv.In(loc)), nil
 }
 
 type builtinMethod func(fnname string, recv starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error)


### PR DESCRIPTION
These methods make it easy to display the current time in a given
location and in a desired format. For example:

    time.now().in_location("US/Pacific").format("3:04 PM")