### PR TITLE
Typos corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
       Issues
     </a>
      <span> | </span>
-    <a href="https://qri.io/docs/reference/starlib/">
+    <a href="https://qri.io/docs/starlark/starlib">
       Docs
     </a>
   </h3>
@@ -37,7 +37,7 @@ This is a community-driven project to bring a standard library to the starlark p
 
 | Question | Answer |
 |--------|-------|
-| "What's starlark?" | It's a python-like scripting language open-sourced by Google. [Here's the Docs](https://docs.bazel.build/versions/master/skylark/language.html) |
+| "What's starlark?" | It's a python-like scripting language open-sourced by Google. [Here are the docs](https://docs.bazel.build/versions/master/skylark/language.html) |
 | "What's the use-case for this?" | [We're building it for Qri ('query')](https://qri.io) |
 | "I want to play with starlib outside of Qri" | [Checkout the starlark playground](https://github.com/qri-io/skypg) |
 | "I have a question" | [Create an issue](https://github.com/qri-io/starlib/issues) |
@@ -50,10 +50,11 @@ The following is a list of the packages currently in the standard library
 
 | Package | Go Docs | Description |
 |---------|---------|-------------|
+| [`bsoup`](https://github.com/qri-io/starlib/tree/master/bsoup) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/bsoup?status.svg)](https://godoc.org/github.com/qri-io/starlib/bsoup) |   a beautiful-soup-like API for working with HTML |
 | [`encoding/base64`](https://github.com/qri-io/starlib/tree/master/encoding/base64) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/encoding/base64?status.svg)](https://godoc.org/github.com/qri-io/starlib/encoding/base64) | base64 de/serialization |
 | [`encoding/csv`](https://github.com/qri-io/starlib/tree/master/encoding/csv) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/encoding/csv?status.svg)](https://godoc.org/github.com/qri-io/starlib/encoding/csv) | csv de/serialization |
 | [`encoding/json`](https://github.com/qri-io/starlib/tree/master/encoding/json) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/encoding/json?status.svg)](https://godoc.org/github.com/qri-io/starlib/encoding/json) | json de/serialization |
-| [`geo`](https://github.com/qri-io/starlib/tree/master/geo) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/geo?status.svg)](https://godoc.org/github.com/qri-io/starlib/geo) | html text processing |
+| [`geo`](https://github.com/qri-io/starlib/tree/master/geo) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/geo?status.svg)](https://godoc.org/github.com/qri-io/starlib/geo) |  2d geographic operations |
 | [`html`](https://github.com/qri-io/starlib/tree/master/html) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/html?status.svg)](https://godoc.org/github.com/qri-io/starlib/html) | html text processing |
 | [`http`](https://github.com/qri-io/starlib/tree/master/http) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/http?status.svg)](https://godoc.org/github.com/qri-io/starlib/http) | http client operations |
 | [`math`](https://github.com/qri-io/starlib/tree/master/math) | <img width=190/>[![Go Docs](https://godoc.org/github.com/qri-io/starlib/math?status.svg)](https://godoc.org/github.com/qri-io/starlib/math) | mathematical functions & values |

--- a/bsoup/README.md
+++ b/bsoup/README.md
@@ -1,0 +1,41 @@
+# bsoup
+bsoup defines a beautiful-soup-like API for working with HTML documents
+
+## Functions
+
+#### `parseHtml(html string) SoupNode`
+parseHtml parses html from a string, returning the root SoupNode
+
+
+## Types
+
+### `SoupNode`
+
+**Methods**
+#### `find(name, attrs, recursive, string, **kwargs)`
+retrieve the first occurance of an element that matches arguments passed to find. works similarly to [node.find()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find)
+
+#### `find_all(name, attrs, recursive, string, limit, **kwargs)`
+retrieves all descendants that match arguments passed to find_all. works similarly to [node.find_all()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all)
+
+#### `attrs()`
+get a dictionary of element attributes works similarly to [node.attrs](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#attributes)
+
+#### `contents()`
+gets the list of children of an element works similarly to [soup.contents](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#contents-and-children)
+
+#### `child()`
+gets a single child element with the given tag name works like accessing a node [using its tag name](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#navigating-using-tag-names)
+
+#### `parent()`
+gets the parent node of an element works like [node.parent](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#parent)
+
+#### `next_sibling()`
+gets the next sibling of an element works like [node.next_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
+
+#### `prev_sibling()`
+gets the previous sibling of an element works like [node.prev_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
+
+#### `get_text()`
+all the text in a document or beneath a tag, as a single Unicode string: works like [soup.get_text](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#get-text)
+

--- a/bsoup/doc.go
+++ b/bsoup/doc.go
@@ -1,41 +1,40 @@
-/*Package bsoup defines a beautiful-soup-like API for working with HTML documents
-in starlark
+/*Package bsoup defines a beautiful-soup-like API for working with HTML documents in starlark
 
- outline: bsoup
-   bsoup defines a beautiful-soup-like API for working with HTML documents
-   path: bsoup
-   types:
-     SoupNode
-       methods:
-         find(name, attrs, recursive, string, **kwargs)
-           retrieve the first occurance of an element that matches arguments passed to find.
-           works similarly to [node.find()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find)
-         find_all(name, attrs, recursive, string, limit, **kwargs)
-           retrieves all descendants that match arguments passed to find_all.
-           works similarly to [node.find_all()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all)
-         attrs()
-           get a dictionary of element attributes
-           works similarly to [node.attrs](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#attributes)
-         contents()
-           gets the list of children of an element
-           works similarly to [soup.contents](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#contents-and-children)
-         child()
-           gets a single child element with the given tag name
-           works like accessing a node [using its tag name](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#navigating-using-tag-names)
-         parent()
-           gets the parent node of an element
-           works like [node.parent](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#parent)
-         next_sibling()
-           gets the next sibling of an element
-           works like [node.next_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
-         prev_sibling()
-           gets the previous sibling of an element
-           works like [node.prev_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
-         get_text()
-           all the text in a document or beneath a tag, as a single Unicode string:
-           works like [soup.get_text](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#get-text)
-   functions:
-     parseHtml(html string) SoupNode
-       parseHtml parses html from a string, returning the root SoupNode
+  outline: bsoup
+    bsoup defines a beautiful-soup-like API for working with HTML documents
+    path: bsoup
+    types:
+      SoupNode
+        methods:
+          find(name, attrs, recursive, string, **kwargs)
+            retrieve the first occurance of an element that matches arguments passed to find.
+            works similarly to [node.find()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find)
+          find_all(name, attrs, recursive, string, limit, **kwargs)
+            retrieves all descendants that match arguments passed to find_all.
+            works similarly to [node.find_all()](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#find-all)
+          attrs()
+            get a dictionary of element attributes
+            works similarly to [node.attrs](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#attributes)
+          contents()
+            gets the list of children of an element
+            works similarly to [soup.contents](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#contents-and-children)
+          child()
+            gets a single child element with the given tag name
+            works like accessing a node [using its tag name](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#navigating-using-tag-names)
+          parent()
+            gets the parent node of an element
+            works like [node.parent](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#parent)
+          next_sibling()
+            gets the next sibling of an element
+            works like [node.next_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
+          prev_sibling()
+            gets the previous sibling of an element
+            works like [node.prev_sibling](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#next-sibling-and-previous-sibling)
+          get_text()
+            all the text in a document or beneath a tag, as a single Unicode string:
+            works like [soup.get_text](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#get-text)
+    functions:
+      parseHtml(html string) SoupNode
+        parseHtml parses html from a string, returning the root SoupNode
 */
 package bsoup

--- a/html/README.md
+++ b/html/README.md
@@ -1,10 +1,10 @@
 # html
-html defines a jquery-like html selection & iteration functions for HTML documents
+html defines jquery-like html selection & iteration functions for HTML documents
 
 ## Functions
 
 #### `html(markup) selection`
-parse an html document returing a selection at the root of the document
+parse an html document returning a selection at the root of the document
 
 **parameters:**
 

--- a/html/doc.go
+++ b/html/doc.go
@@ -1,11 +1,11 @@
 /*Package html defines a jquery-like html selection & iteration functions for HTML documents
 
   outline: html
-    html defines a jquery-like html selection & iteration functions for HTML documents
+    html defines jquery-like html selection & iteration functions for HTML documents
 
     functions:
       html(markup) selection
-        parse an html document returing a selection at the root of the document
+        parse an html document returning a selection at the root of the document
         params:
           markup string
             html text to build a document from


### PR DESCRIPTION
Typos, corrections, generated bsoup README.md.

Corrected /html/README.md before I saw that it was autogenerated. But it matches the regenerated README.md, so it doesn’t show up in the diff after regeneration.