### PR TITLE
feat(time): Add unix and unix_nano methods

### DIFF
--- a/time/doc.go
+++ b/time/doc.go
@@ -37,11 +37,13 @@ package from the go standard library.
           minute() int
           second() int
           nanosecond() int
-		  in_location(string) time
-		  	get time representing the same instant but in a different location
-		  format(string) string
-		  	textual representation of time formatted according to the provided
-			layout string
+          unix() int
+          unix_nano() int
+          in_location(string) time
+            get time representing the same instant but in a different location
+          format(string) string
+            textual representation of time formatted according to the provided
+            layout string
         operators:
           time == time = boolean
           time < time = boolean

--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -27,5 +27,7 @@ assert.eq(10.0, d2.hours())
 assert.eq(10*60.0, d2.minutes())
 assert.eq(10*60*60.0, d2.seconds())
 assert.eq(10*60*60*1000000000, d2.nanoseconds())
+assert.eq(time.zero.unix(), 0)
+assert.eq(time.zero.unix_nano(), 0)
 
 time.sleep(time.second)

--- a/time/time.go
+++ b/time/time.go
@@ -309,6 +309,8 @@ var timeMethods = map[string]builtinMethod{
 	"minute":     timeminute,
 	"second":     timesecond,
 	"nanosecond": timenanosecond,
+	"unix":       timeunix,
+	"unix_nano":  timeunixnano,
 
 	"in_location": timein,
 	"format":      timeformat,
@@ -343,6 +345,16 @@ func timeminute(fnname string, recV starlark.Value, args starlark.Tuple, kwargs 
 func timesecond(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	recv := gotime.Time(recV.(Time))
 	return starlark.MakeInt(recv.Second()), nil
+}
+
+func timeunix(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	recv := gotime.Time(recV.(Time))
+	return starlark.MakeInt64(recv.Unix()), nil
+}
+
+func timeunixnano(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	recv := gotime.Time(recV.(Time))
+	return starlark.MakeInt64(recv.UnixNano()), nil
 }
 
 func timenanosecond(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {


### PR DESCRIPTION
This allows converting a time object to a unix timestamp.