### PR TITLE
feat(time): Add fromtimestamp method

### DIFF
--- a/time/doc.go
+++ b/time/doc.go
@@ -11,6 +11,8 @@ package from the go standard library.
         parse a location
       time(string, format=..., location=...) time
         parse a time
+      fromtimestamptime(int) time
+        parse a Unix timestamp
       now() time
         implementations would be able to make this a constant
       zero() time

--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -7,6 +7,8 @@ assert.true(time.time("2010-04-22T13:33:48Z") < time.time("2011-04-22T13:33:48Z"
 assert.true(time.time("2011-04-22T13:33:48Z") == time.time("2011-04-22T13:33:48Z"))
 assert.true(time.time("2012-04-22T13:33:48Z") > time.time("2011-04-22T13:33:48Z"))
 
+assert.eq(time.time("2020-06-26T17:38:36Z"), time.fromtimestamp(1593193116))
+
 # zero
 assert.eq(time.zero.format("Mon Jan 2 15:04:05 -0700 MST 2006"), "Mon Jan 1 00:00:00 +0000 UTC 0001")
 

--- a/time/time.go
+++ b/time/time.go
@@ -3,6 +3,7 @@ package time
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	gotime "time"
 
@@ -29,12 +30,13 @@ func LoadModule() (starlark.StringDict, error) {
 			"time": &starlarkstruct.Module{
 				Name: "time",
 				Members: starlark.StringDict{
-					"duration": starlark.NewBuiltin("duration", duration),
-					"location": starlark.NewBuiltin("location", location),
-					"now":      starlark.NewBuiltin("now", now),
-					"struct":   starlark.NewBuiltin("struct", starlarkstruct.Make),
-					"time":     starlark.NewBuiltin("time", time),
-					"sleep":    starlark.NewBuiltin("sleep", sleep),
+					"duration":      starlark.NewBuiltin("duration", duration),
+					"location":      starlark.NewBuiltin("location", location),
+					"now":           starlark.NewBuiltin("now", now),
+					"struct":        starlark.NewBuiltin("struct", starlarkstruct.Make),
+					"time":          starlark.NewBuiltin("time", time),
+					"sleep":         starlark.NewBuiltin("sleep", sleep),
+					"fromtimestamp": starlark.NewBuiltin("fromtimestamp", fromtimestamp),
 
 					"zero": Time{},
 
@@ -125,6 +127,24 @@ func time(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwa
 	if err != nil {
 		return nil, err
 	}
+	return Time(t), nil
+}
+
+func fromtimestamp(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		x starlark.Int
+	)
+	if err := starlark.UnpackArgs("time", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+
+	i, err := strconv.ParseInt(x.String(), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	t := gotime.Unix(i, 0)
+
 	return Time(t), nil
 }
 


### PR DESCRIPTION
`time.fromtimestamp` parses a Unix timestamp integer to a time.time object

Based on the [`datetime.fromtimestamp()`](https://docs.python.org/3/library/datetime.html#datetime.date.fromtimestamp) method in Python

Example:

```python
assert.eq(time.time("2020-06-26T17:38:36Z"), time.fromtimestamp(1593193116))
```