### PR TITLE
feat(time): Add strftime method to time instances

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ replace (
 require (
 	github.com/360EntSecGroup-Skylar/excelize v1.4.1
 	github.com/PuerkitoBio/goquery v1.5.1
+	github.com/cactus/gostrftime v0.0.0-20190922123236-884915fd58c8
 	github.com/dustmop/soup v1.1.2-0.20190516214245-38228baa104e
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/paulmach/orb v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154Oa
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
+github.com/cactus/gostrftime v0.0.0-20190922123236-884915fd58c8 h1:ZLNWSjNUR7xeqUJ3giWDUKDp6dFgzPh7cZORk2L91RQ=
+github.com/cactus/gostrftime v0.0.0-20190922123236-884915fd58c8/go.mod h1:GZmSLhWIIhWUefT7AvYcPIUbE5JTHH75IafPqyqXBpg=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=

--- a/time/doc.go
+++ b/time/doc.go
@@ -46,6 +46,9 @@ package from the go standard library.
           format(string) string
             textual representation of time formatted according to the provided
             layout string
+          strftime(string) string
+            textual representation of time formatted according to the provided C-style strftime format string
+            layout string
         operators:
           time == time = boolean
           time < time = boolean

--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -9,6 +9,9 @@ assert.true(time.time("2012-04-22T13:33:48Z") > time.time("2011-04-22T13:33:48Z"
 
 assert.eq(time.time("2020-06-26T17:38:36Z"), time.fromtimestamp(1593193116))
 
+assert.eq(time.time("2020-06-26T17:38:36Z").strftime("%Y"), "2020")
+assert.eq(time.time("2020-06-26T17:38:36Z").strftime("%F %R"), "2020-06-26 17:38")
+
 # zero
 assert.eq(time.zero.format("Mon Jan 2 15:04:05 -0700 MST 2006"), "Mon Jan 1 00:00:00 +0000 UTC 0001")
 

--- a/time/time.go
+++ b/time/time.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	gotime "time"
 
+	"github.com/cactus/gostrftime"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 	"go.starlark.net/syntax"
@@ -334,6 +335,7 @@ var timeMethods = map[string]builtinMethod{
 
 	"in_location": timein,
 	"format":      timeformat,
+	"strftime":    timestrftime,
 }
 
 // TODO - consider using a higher order function to generate these
@@ -390,6 +392,16 @@ func timeformat(fnname string, recV starlark.Value, args starlark.Tuple, kwargs 
 
 	recv := gotime.Time(recV.(Time))
 	return starlark.String(recv.Format(string(x))), nil
+}
+
+func timestrftime(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x starlark.String
+	if err := starlark.UnpackArgs("strftime", args, kwargs, "x", &x); err != nil {
+		return nil, err
+	}
+
+	recv := gotime.Time(recV.(Time))
+	return starlark.String(gostrftime.Format(string(x), recv)), nil
 }
 
 func timein(fnname string, recV starlark.Value, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {


### PR DESCRIPTION
Allow for formating times using C-style strftime format strings

Example:
```
assert.eq(time.time("2020-06-26T17:38:36Z").strftime("%Y"), "2020")
assert.eq(time.time("2020-06-26T17:38:36Z").strftime("%F %R"), "2020-06-26 17:38")
```

Introduces a dependency on [gostrftime](https://godoc.org/github.com/cactus/gostrftime). Chosen because it is the most popular strftime library on godoc.org ([source](https://godoc.org/?q=strftime)).