### PR TITLE
feat(http): support URL encoding for forms

### DIFF
--- a/http/doc.go
+++ b/http/doc.go
@@ -13,7 +13,7 @@
             optional. dictionary of headers to add to request
           auth tuple
             optional. (username,password) tuple for http basic authorization
-      put(url,params={},headers={},body="",form_body={},json_body={},auth=()) response
+      put(url,params={},headers={},body="",form_body={},form_encoding="",json_body={},auth=()) response
         perform an HTTP PUT request, returning a response
         params:
           url string
@@ -24,11 +24,13 @@
             optional. raw string body to provide to the request
           form_body dict
             optional. dict of values that will be encoded as form data
+          form_encoding string
+            optional. `application/x-www-form-url-encoded` (default) or `multipart/form-data`
           json_body any
             optional. json data to supply as a request. handy for working with JSON-API's
           auth tuple
             optional. (username,password) tuple for http basic authorization
-      post(url,params={},headers={},body="",form_body={},json_body={},auth=()) response
+      post(url,params={},headers={},body="",form_body={},form_encoding="",json_body={},auth=()) response
         perform an HTTP POST request, returning a response
         params:
           url string
@@ -39,11 +41,13 @@
             optional. raw string body to provide to the request
           form_body dict
             optional. dict of values that will be encoded as form data
+          form_encoding string
+            optional. `application/x-www-form-url-encoded` (default) or `multipart/form-data`
           json_body any
             optional. json data to supply as a request. handy for working with JSON-API's
           auth tuple
             optional. (username,password) tuple for http basic authorization
-      delete(url,params={},headers={},body="",form_body={},json_body={},auth=()) response
+      delete(url,params={},headers={},body="",form_body={},form_encoding="",json_body={},auth=()) response
         perform an HTTP DELETE request, returning a response
         params:
           url string
@@ -54,11 +58,13 @@
             optional. raw string body to provide to the request
           form_body dict
             optional. dict of values that will be encoded as form data
+          form_encoding string
+            optional. `application/x-www-form-url-encoded` (default) or `multipart/form-data`
           json_body any
             optional. json data to supply as a request. handy for working with JSON-API's
           auth tuple
             optional. (username,password) tuple for http basic authorization
-      patch(url,params={},headers={},body="",form_body={},json_body={},auth=()) response
+      patch(url,params={},headers={},body="",form_body={},form_encoding="",json_body={},auth=()) response
         perform an HTTP PATCH request, returning a response
         params:
           url string
@@ -69,11 +75,13 @@
             optional. raw string body to provide to the request
           form_body dict
             optional. dict of values that will be encoded as form data
+          form_encoding string
+            optional. `application/x-www-form-url-encoded` (default) or `multipart/form-data`
           json_body any
             optional. json data to supply as a request. handy for working with JSON-API's
           auth tuple
             optional. (username,password) tuple for http basic authorization
-      options(url,params={},headers={},body="",form_body={},json_body={},auth=()) response
+      options(url,params={},headers={},body="",form_body={},form_encoding="",json_body={},auth=()) response
         perform an HTTP OPTIONS request, returning a response
         params:
           url string
@@ -84,6 +92,8 @@
             optional. raw string body to provide to the request
           form_body dict
             optional. dict of values that will be encoded as form data
+          form_encoding string
+            optional. `application/x-www-form-url-encoded` (default) or `multipart/form-data`
           json_body any
             optional. json data to supply as a request. handy for working with JSON-API's
           auth tuple

--- a/http/http.go
+++ b/http/http.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -273,7 +274,7 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, f
 			form.Add(keystr, valstr)
 		}
 
-		var enc string
+		var contentType string
 		switch formEncoding {
 		case formEncodingURL, "":
 			contentType = formEncodingURL
@@ -305,7 +306,7 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, f
 		}
 
 		if req.Header.Get("Content-Type") == "" {
-			req.Header.Set("Content-Type", enc)
+			req.Header.Set("Content-Type", contentType)
 		}
 	}
 

--- a/http/http.go
+++ b/http/http.go
@@ -33,6 +33,14 @@ var (
 	Guard RequestGuard
 )
 
+// Encodings for form data.
+//
+// See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST
+const (
+	formEncodingMultipart = "multipart/form-data"
+	formEncodingURL       = "application/x-www-form-urlencoded"
+)
+
 // LoadModule creates an http Module
 func LoadModule() (starlark.StringDict, error) {
 	var m = &Module{cli: Client}
@@ -80,16 +88,17 @@ func (m *Module) StringDict() starlark.StringDict {
 func (m *Module) reqMethod(method string) func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	return func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var (
-			urlv     starlark.String
-			params   = &starlark.Dict{}
-			headers  = &starlark.Dict{}
-			formBody = &starlark.Dict{}
-			auth     starlark.Tuple
-			body     starlark.String
-			jsonBody starlark.Value
+			urlv         starlark.String
+			params       = &starlark.Dict{}
+			headers      = &starlark.Dict{}
+			formBody     = &starlark.Dict{}
+			formEncoding starlark.String
+			auth         starlark.Tuple
+			body         starlark.String
+			jsonBody     starlark.Value
 		)
 
-		if err := starlark.UnpackArgs(method, args, kwargs, "url", &urlv, "params?", &params, "headers", &headers, "body", &body, "form_body", &formBody, "json_body", &jsonBody, "auth", &auth); err != nil {
+		if err := starlark.UnpackArgs(method, args, kwargs, "url", &urlv, "params?", &params, "headers", &headers, "body", &body, "form_body", &formBody, "form_encoding", &formEncoding, "json_body", &jsonBody, "auth", &auth); err != nil {
 			return nil, err
 		}
 
@@ -117,7 +126,7 @@ func (m *Module) reqMethod(method string) func(thread *starlark.Thread, _ *starl
 		if err = setAuth(req, auth); err != nil {
 			return nil, err
 		}
-		if err = setBody(req, body, formBody, jsonBody); err != nil {
+		if err = setBody(req, body, formBody, formEncoding, jsonBody); err != nil {
 			return nil, err
 		}
 
@@ -217,7 +226,7 @@ func setHeaders(req *http.Request, headers *starlark.Dict) error {
 	return nil
 }
 
-func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, jsondata starlark.Value) error {
+func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, formEncoding starlark.String, jsondata starlark.Value) error {
 	if !util.IsEmptyString(body) {
 		uq, err := strconv.Unquote(body.String())
 		if err != nil {
@@ -242,13 +251,7 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, j
 	}
 
 	if formData != nil && formData.Len() > 0 {
-		if req.Header.Get("Content-Type") == "" {
-			req.Header.Set("Content-Type", "multipart/form-data")
-		}
-
-		if req.Form == nil {
-			req.Form = url.Values{}
-		}
+		form := url.Values{}
 		for _, key := range formData.Keys() {
 			keystr, err := AsString(key)
 			if err != nil {
@@ -267,7 +270,42 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, j
 				return err
 			}
 
-			req.Form.Add(keystr, valstr)
+			form.Add(keystr, valstr)
+		}
+
+		var enc string
+		switch formEncoding {
+		case formEncodingURL, "":
+			contentType = formEncodingURL
+			req.Body = ioutil.NopCloser(strings.NewReader(form.Encode()))
+
+		case formEncodingMultipart:
+			var b bytes.Buffer
+			mw := multipart.NewWriter(&b)
+			defer mw.Close()
+
+			contentType = mw.FormDataContentType()
+
+			for k, values := range form {
+				for _, v := range values {
+					w, err := mw.CreateFormField(k)
+					if err != nil {
+						return err
+					}
+					if _, err := w.Write([]byte(v)); err != nil {
+						return err
+					}
+				}
+			}
+
+			req.Body = ioutil.NopCloser(&b)
+
+		default:
+			return fmt.Errorf("unknown form encoding: %s", formEncoding)
+		}
+
+		if req.Header.Get("Content-Type") == "" {
+			req.Header.Set("Content-Type", enc)
 		}
 	}
 


### PR DESCRIPTION
Add the `form_encoding` parameter to HTTP methods. When it is set to
`application/x-www-form-urlencoded`, encode form data as a string of
key-value pairs. This is the same encoding as Go's `http.PostForm`.