### PR TITLE
fix(util): handle tuples correctly

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -33,6 +33,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.3-0.20181224173747-660f15d67dbb/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 go.starlark.net v0.0.0-20200330013621-be5394c419b6 h1:S2s+dYPyDg/vF7KbcRIB2831xVimJoR4zebfoVBzn7Q=

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -82,7 +82,7 @@ func TestSetBody(t *testing.T) {
 		{starlark.String("hallo"), nil, nil, "hallo", ""},
 		// TODO - this should check request form data is being set
 		{starlark.String(""), fd, nil, "", ""},
-		{starlark.String(""), nil, &starlark.Tuple{starlark.Bool(true), starlark.MakeInt(1), starlark.String("der")}, "[true,1,\"der\"]", ""},
+		{starlark.String(""), nil, starlark.Tuple{starlark.Bool(true), starlark.MakeInt(1), starlark.String("der")}, "[true,1,\"der\"]", ""},
 	}
 
 	for i, c := range cases {

--- a/util/util.go
+++ b/util/util.go
@@ -117,7 +117,7 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 			i++
 		}
 		val = value
-	case *starlark.Tuple:
+	case starlark.Tuple:
 		var (
 			i        int
 			tupleVal starlark.Value

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -138,6 +138,7 @@ func TestUnmarshal(t *testing.T) {
 		{ct, &customType{42}, ""},
 		{strDictCT, map[string]interface{}{"foo": 42, "bar": &customType{42}}, ""},
 		{starlark.NewList([]starlark.Value{starlark.MakeInt(42), ct}), []interface{}{42, &customType{42}}, ""},
+		{starlark.Tuple{starlark.String("foo"), starlark.MakeInt(42)}, []interface{}{"foo", 42}, ""},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
`starlark.Tuple` is actually just an alias for `[]starlark.Value`. So
when a Starlark function returns a tuple, it is a `starlark.Tuple` and
not `*starlark.Tuple`.