### PR TITLE
feat(time): make string representation reversible

### DIFF
--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -19,6 +19,7 @@ t = time.time("2000-01-02T03:04:05Z")
 assert.eq(t.year(), 2000)
 assert.eq(t.in_location("US/Eastern"), time.time("2000-01-01T22:04:05-05:00"))
 assert.eq(t.in_location("US/Eastern").format("3 04 PM"), "10 04 PM")
+assert.eq(time.time(str(t)), t)
 
 assert.eq(t - t, time.duration("0s"))
 

--- a/time/time.go
+++ b/time/time.go
@@ -256,7 +256,7 @@ func durationnanoseconds(fnname string, recV starlark.Value, args starlark.Tuple
 type Time gotime.Time
 
 // String implements the Stringer interface
-func (t Time) String() string { return gotime.Time(t).String() }
+func (t Time) String() string { return gotime.Time(t).Format(gotime.RFC3339) }
 
 // Type returns a short string describing the value's type.
 func (t Time) Type() string { return "time" }


### PR DESCRIPTION
Since `time(some_str)` assumes that `some_str` is in RFC3339 format, make
`str(time)` output a string in that format. This gives us the very
useful new property that `time(str(some_time)) == some_time`.