### PR TITLE
Fix typo in the hash module's README.md

### DIFF
--- a/hash/README.md
+++ b/hash/README.md
@@ -1,4 +1,4 @@
-# time
+# hash
 
 hash defines hash primitives for starlark
 


### PR DESCRIPTION
Should be hash instead of time.