### PR TITLE
fix(time): fix location parsing in time()

### DIFF
--- a/time/testdata/test.star
+++ b/time/testdata/test.star
@@ -18,6 +18,9 @@ assert.eq(time.zero.format("Mon Jan 2 15:04:05 -0700 MST 2006"), "Mon Jan 1 00:0
 t = time.time("2000-01-02T03:04:05Z")
 assert.eq(t.year(), 2000)
 assert.eq(t.in_location("US/Eastern"), time.time("2000-01-01T22:04:05-05:00"))
+assert.eq(t.in_location("US/Eastern"), time.time("2000-01-01T22:04:05",
+                                                 format="2006-01-02T15:04:05",
+                                                 location="US/Eastern"))
 assert.eq(t.in_location("US/Eastern").format("3 04 PM"), "10 04 PM")
 assert.eq(time.time(str(t)), t)
 

--- a/time/time.go
+++ b/time/time.go
@@ -120,7 +120,7 @@ func time(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwa
 		return Time(t), nil
 	}
 
-	loc, err := gotime.LoadLocation(location.String())
+	loc, err := gotime.LoadLocation(string(location))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Calling .String() on location produces a quoted string, resulting
an error from LoadLocation().