### PR TITLE
fix(math,time): restore ".star" suffixes to math & time modules

### DIFF
--- a/math/doc.go
+++ b/math/doc.go
@@ -85,6 +85,10 @@ package math
 
 import "go.starlark.net/lib/math"
 
+// ModuleName declares the intended load import string
+// eg: load("math.star", "math")
+const ModuleName = "math.star"
+
 // Module exposes the time module. Implementation located at
 // https://github.com/google/starlark-go/tree/master/lib/math
 var Module = math.Module

--- a/starlib.go
+++ b/starlib.go
@@ -12,11 +12,11 @@ import (
 	"github.com/qri-io/starlib/hash"
 	"github.com/qri-io/starlib/html"
 	"github.com/qri-io/starlib/http"
+	"github.com/qri-io/starlib/math"
 	"github.com/qri-io/starlib/re"
+	"github.com/qri-io/starlib/time"
 	"github.com/qri-io/starlib/xlsx"
 	"github.com/qri-io/starlib/zipfile"
-	"go.starlark.net/lib/math"
-	"go.starlark.net/lib/time"
 	"go.starlark.net/starlark"
 )
 
@@ -26,10 +26,8 @@ const Version = "0.4.3-dev"
 // Loader presents the starlib library as a loader
 func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, err error) {
 	switch module {
-	case time.Module.Name:
-		return starlark.StringDict{
-			"time": time.Module,
-		}, nil
+	case time.ModuleName:
+		return starlark.StringDict{"time": time.Module}, nil
 	case http.ModuleName:
 		return http.LoadModule()
 	case xlsx.ModuleName:
@@ -52,10 +50,8 @@ func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, e
 		return yaml.LoadModule()
 	case geo.ModuleName:
 		return geo.LoadModule()
-	case math.Module.Name:
-		return starlark.StringDict{
-			"math": math.Module,
-		}, nil
+	case math.ModuleName:
+		return starlark.StringDict{"math": math.Module}, nil
 	case hash.ModuleName:
 		return hash.LoadModule()
 	}

--- a/time/doc.go
+++ b/time/doc.go
@@ -84,6 +84,10 @@ package time
 
 import "go.starlark.net/lib/time"
 
+// ModuleName declares the intended load import string
+// eg: load("time.star", "time")
+const ModuleName = "time.star"
+
 // Module exposes the time module. Implementation located at
 // https://github.com/google/starlark-go/tree/master/lib/time
 var Module = time.Module


### PR DESCRIPTION
hotfix for a mistake in the way imports should work. based on tests in go-starlark, we're keeping the .star suffix apparently. This restores import paths to their prior (non-breaking between releases) versions:

`load("time", "time")` -> `load("time.star", "time")`
`load("math", "time")` -> `load("math.star", "time")`

package APIs are still locked to the upstream time & math modules