### PR TITLE
Fix unmarshaling of 64 bit integers

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -32,7 +32,9 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 	case starlark.Bool:
 		val = v.Truth() == starlark.True
 	case starlark.Int:
-		val, err = starlark.AsInt32(x)
+		var tmp int
+		err = starlark.AsInt(x, &tmp)
+		val = tmp
 	case starlark.Float:
 		if f, ok := starlark.AsFloat(x); !ok {
 			err = fmt.Errorf("couldn't parse float")


### PR DESCRIPTION
Had to also change marshaling tests to use Starlark's `Equal` instead of just comparing by value (it doesn't work for big integers). 