### PR TITLE
Index and basic DataFrame with columns

### DIFF
--- a/dataframe/convert.go
+++ b/dataframe/convert.go
@@ -2,6 +2,7 @@ package dataframe
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"go.starlark.net/starlark"
@@ -27,71 +28,51 @@ func toStrOrEmpty(v starlark.Value) string {
 }
 
 // convert starlark value to a list of strings, fit for printing, or nil if not possible
-func toStrListOrNil(v starlark.Value) []string {
-	if v == nil {
-		return nil
-	}
-	if v == starlark.None {
-		return nil
-	}
-
-	list, ok := v.(*starlark.List)
-	if ok {
-		result := make([]string, 0, list.Len())
-		for i := 0; i < list.Len(); i++ {
-			result = append(result, toStr(list.Index(i)))
+func toStrSliceOrNil(v starlark.Value) []string {
+	switch x := v.(type) {
+	case *starlark.List:
+		result := make([]string, 0, x.Len())
+		for i := 0; i < x.Len(); i++ {
+			result = append(result, toStr(x.Index(i)))
 		}
 		return result
-	}
-
-	tup, ok := v.(starlark.Tuple)
-	if ok {
-		result := make([]string, 0, tup.Len())
-		for i := 0; i < tup.Len(); i++ {
-			result = append(result, toStr(tup.Index(i)))
+	case starlark.Tuple:
+		result := make([]string, 0, x.Len())
+		for i := 0; i < x.Len(); i++ {
+			result = append(result, toStr(x.Index(i)))
 		}
 		return result
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 // convert starlark value to a list of any values, or nil if not a list
-func toInterfaceListOrNil(v starlark.Value) []interface{} {
-	if v == nil {
-		return nil
-	}
-	if v == starlark.None {
-		return nil
-	}
-
-	list, ok := v.(*starlark.List)
-	if ok {
-		result := make([]interface{}, 0, list.Len())
-		for i := 0; i < list.Len(); i++ {
-			elem, ok := toScalarMaybe(list.Index(i))
+func toInterfaceSliceOrNil(v starlark.Value) []interface{} {
+	switch x := v.(type) {
+	case *starlark.List:
+		result := make([]interface{}, 0, x.Len())
+		for i := 0; i < x.Len(); i++ {
+			elem, ok := toScalarMaybe(x.Index(i))
 			if !ok {
 				return nil
 			}
 			result = append(result, elem)
 		}
 		return result
-	}
-
-	tup, ok := v.(starlark.Tuple)
-	if ok {
-		result := make([]interface{}, 0, tup.Len())
-		for i := 0; i < tup.Len(); i++ {
-			elem, ok := toScalarMaybe(tup.Index(i))
+	case starlark.Tuple:
+		result := make([]interface{}, 0, x.Len())
+		for i := 0; i < x.Len(); i++ {
+			elem, ok := toScalarMaybe(x.Index(i))
 			if !ok {
 				return nil
 			}
 			result = append(result, elem)
 		}
 		return result
+	default:
+		return nil
 	}
-
-	return nil
 }
 
 // convert starlark value to a go native int if it has the right type
@@ -142,7 +123,7 @@ func toScalarMaybe(v starlark.Value) (interface{}, bool) {
 }
 
 func toIndexMaybe(v starlark.Value) (*Index, bool) {
-	texts := toStrListOrNil(v)
+	texts := toStrSliceOrNil(v)
 	if texts != nil {
 		return NewIndex(texts, ""), true
 	}
@@ -185,24 +166,30 @@ func convertFloatsToStrings(vals []float64) []string {
 
 // convert one of the supported go native data types into a starlark value
 func convertToStarlark(it interface{}) (starlark.Value, error) {
-	if num, ok := it.(int); ok {
-		return starlark.MakeInt(num), nil
+	switch x := it.(type) {
+	case int:
+		return starlark.MakeInt(x), nil
+	case float64:
+		return starlark.Float(x), nil
+	case string:
+		return starlark.String(x), nil
+	default:
+		return starlark.None, fmt.Errorf("unknown type of %v", reflect.TypeOf(it))
 	}
-	if f, ok := it.(float64); ok {
-		return starlark.Float(f), nil
-	}
-	if str, ok := it.(string); ok {
-		return starlark.String(str), nil
-	}
-	return starlark.None, fmt.Errorf("unknown type of %v", it)
 }
 
 func coerceToDatatype(text, dtype string) string {
 	if dtype == "bool" {
+		// Convert bool to string version, instead of int
+		// TODO(dustmop): Bit of a hack, the caller of this should perhaps use
+		// `values()` instead of `stringValues()` so that this argument is an
+		// interface, not a string. That would remove this unneeded stringification
+		// from `1` to `"1"` to `"True"`.
 		if text == "1" {
-			return " True"
+			return "True"
 		}
 		return "False"
 	}
+	// Every other type has been properly stringified by the time it gets here.
 	return text
 }

--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -1,6 +1,9 @@
 package dataframe
 
 import (
+	"fmt"
+	"strings"
+
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
@@ -16,6 +19,402 @@ const (
 var Module = &starlarkstruct.Module{
 	Name: Name,
 	Members: starlark.StringDict{
-		"Series": starlark.NewBuiltin("Series", newSeries),
+		"DataFrame": starlark.NewBuiltin("DataFrame", newDataFrame),
+		"Index":     starlark.NewBuiltin("Index", newIndex),
+		"Series":    starlark.NewBuiltin("Series", newSeries),
 	},
+}
+
+// DataFrame is the primary data structure of this package, it represents
+// a column-oriented table of data, and provides spreadsheet and sql like
+// functionality.
+type DataFrame struct {
+	frozen  bool
+	columns *Index
+	index   *Index
+	body    []Series
+}
+
+// compile-time interface assertions
+var (
+	_ starlark.Value       = (*DataFrame)(nil)
+	_ starlark.Mapping     = (*DataFrame)(nil)
+	_ starlark.HasAttrs    = (*DataFrame)(nil)
+	_ starlark.HasSetField = (*DataFrame)(nil)
+	_ starlark.HasSetKey   = (*DataFrame)(nil)
+)
+
+func newDataFrame(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		dataVal, indexVal, columnsVal, dtypeVal starlark.Value
+		kopyVal                                 starlark.Bool
+	)
+	if err := starlark.UnpackArgs("DataFrame", args, kwargs,
+		"data?", &dataVal,
+		"index?", &indexVal,
+		"columns?", &columnsVal,
+		"dtype?", &dtypeVal,
+		"copy?", &kopyVal,
+	); err != nil {
+		return nil, err
+	}
+
+	columns := toStrListOrNil(columnsVal)
+	index, _ := toIndexMaybe(indexVal)
+
+	if dataDict, ok := dataVal.(*starlark.Dict); ok {
+		newBody := make([]Series, 0)
+		keyList := make([]string, 0, dataDict.Len())
+		inKeys := dataDict.Keys()
+		numCols := len(inKeys)
+		numRows := -1
+		for i := 0; i < len(inKeys); i++ {
+			// Collect each key, use them as the default index
+			inKey := inKeys[i]
+			keyList = append(keyList, toStr(inKey))
+			// Get each value, which should be a list of values
+			val, _, _ := dataDict.Get(inKey)
+			items := toInterfaceListOrNil(val)
+			if items == nil {
+				return starlark.None, fmt.Errorf("invalid values for column")
+			}
+			// Validate that the size of each column is the same
+			// TODO(dustmop): Add test
+			if numRows == -1 {
+				numRows = len(items)
+			} else if numRows != len(items) {
+				return starlark.None, fmt.Errorf("columns need to be the same length")
+			}
+			// The list of values should be of the same type
+			builder := newTypedArrayBuilder(len(items))
+			for _, it := range items {
+				builder.push(it)
+			}
+			if err := builder.error(); err != nil {
+				return starlark.None, err
+			}
+
+			series := newSeriesFromBuilder(builder, nil, "")
+			newBody = append(newBody, *series)
+		}
+
+		if index.len() > 0 && index.len() != numRows {
+			// TODO(dustmop): Add test
+			return starlark.None, fmt.Errorf("size of index does not match body size")
+		}
+		if len(columns) > 0 && len(columns) != numCols {
+			// TODO(dustmop): Add test
+			return starlark.None, fmt.Errorf("number of columns does not match body size")
+		}
+
+		// TODO(dustmop): `index` will re-index
+		return &DataFrame{
+			columns: NewIndex(keyList, ""),
+			body:    newBody,
+		}, nil
+	}
+
+	if inRowData, ok := dataVal.(*starlark.List); ok {
+		numRows := inRowData.Len()
+		numCols := -1
+		var builders []*typedArrayBuilder
+		// Iterate the input data row-size
+		for y := 0; y < inRowData.Len(); y++ {
+			row := toInterfaceListOrNil(inRowData.Index(y))
+			if row == nil {
+				return starlark.None, fmt.Errorf("invalid values for row")
+			}
+			// Validate that the size of each row is the same
+			// TODO(dustmop): Add test
+			if numCols == -1 {
+				numCols = len(row)
+			} else if numCols != len(row) {
+				return starlark.None, fmt.Errorf("rows need to be the same length")
+			}
+			for x := 0; x < numCols; x++ {
+				// Allocate builders once we know how many and how large they are
+				if builders == nil {
+					builders = make([]*typedArrayBuilder, numCols)
+					for i := 0; i < numCols; i++ {
+						builders[i] = newTypedArrayBuilder(numRows)
+					}
+				}
+				// Accumlate each cell into the appropriate column builder
+				builders[x].push(row[x])
+			}
+		}
+		// Get a series for each column of the body
+		newBody := make([]Series, numCols)
+		for x := 0; x < numCols; x++ {
+			series := newSeriesFromBuilder(builders[x], nil, "")
+			newBody[x] = *series
+		}
+
+		if index.len() > 0 && index.len() != numRows {
+			// TODO(dustmop): Add test
+			return starlark.None, fmt.Errorf("size of index does not match body size")
+		}
+		if len(columns) > 0 && len(columns) != numCols {
+			// TODO(dustmop): Add test
+			return starlark.None, fmt.Errorf("number of columns does not match body size")
+		}
+
+		return &DataFrame{
+			columns: NewIndex(columns, ""),
+			index:   index,
+			body:    newBody,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("Not implemented, constructing DataFrame using %s", dataVal.Type())
+}
+
+func (df *DataFrame) numRows() int {
+	if len(df.body) == 0 {
+		return 0
+	}
+	return df.body[0].len()
+}
+
+// String returns the DataFrame as a string in a readable, tabular form
+func (df *DataFrame) String() string {
+	return df.stringify()
+}
+
+// Type returns a short string describing the value's type.
+func (DataFrame) Type() string { return fmt.Sprintf("%s.DataFrame", Name) }
+
+// Freeze renders DataFrame immutable.
+func (df *DataFrame) Freeze() { df.frozen = true }
+
+// Hash returns a function of x such that Equals(x, y) => Hash(x) == Hash(y)
+// required by starlark.Value interface.
+func (df *DataFrame) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: DataFrame")
+}
+
+// Truth reports whether the DataFrame is non-zero.
+func (df *DataFrame) Truth() starlark.Bool {
+	// NOTE: In python, calling bool(DataFrame) raises this exception: "ValueError: The truth
+	// value of a DataFrame is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+	// Since starlark does not have exceptions, just always return true.
+	return true
+}
+
+// Attr gets a value for a string attribute, implementing dot expression support
+// in starklark. required by starlark.HasAttrs interface.
+func (df *DataFrame) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "columns":
+		return df.columns, nil
+	}
+	return nil, nil
+}
+
+// AttrNames lists available dot expression strings. required by
+// starlark.HasAttrs interface.
+func (df *DataFrame) AttrNames() []string {
+	return []string{"columns"}
+}
+
+// SetField assigns to a field of the DataFrame
+func (df *DataFrame) SetField(name string, val starlark.Value) error {
+	if df.frozen {
+		return fmt.Errorf("cannot set, dataframe is frozen")
+	}
+
+	if name == "columns" {
+		idx, ok := val.(*Index)
+		if !ok {
+			return fmt.Errorf("cannot assign to 'columns', wrong type")
+		}
+		df.columns = idx
+		return nil
+	}
+	return starlark.NoSuchAttrError(name)
+}
+
+// SetKey assigns a value to a DataFrame at the given key
+func (df *DataFrame) SetKey(nameVal, val starlark.Value) error {
+	if df.frozen {
+		return fmt.Errorf("cannot set, dataframe is frozen")
+	}
+
+	name, ok := toStrMaybe(nameVal)
+	if !ok {
+		return fmt.Errorf("SetKey: name must be string")
+	}
+
+	// Figure out if a column already exists with the given name
+	columnIndex := findKeyPos(name, df.columns.texts)
+
+	// Either prepend the new column, or keep the names the same
+	newNames := make([]string, 0, len(df.columns.texts)+1)
+	if columnIndex == -1 {
+		newNames = append([]string{name}, df.columns.texts...)
+	} else {
+		newNames = df.columns.texts
+	}
+
+	// Assignment of a scalar (int, bool, float, string) to the column
+	if scalar, ok := toScalarMaybe(val); ok {
+		var newBody []Series
+		newCol := newSeriesFromRepeatScalar(scalar, max(1, df.numRows()))
+		if columnIndex == -1 {
+			// New columns are added to the left side of the dataframe
+			newBody = append([]Series{*newCol}, df.body...)
+		} else {
+			newBody = df.body
+			newBody[columnIndex] = *newCol
+		}
+		df.columns = NewIndex(newNames, "")
+		df.body = newBody
+		return nil
+	}
+
+	// Assignment of a Series to the column
+	series, ok := val.(*Series)
+	if !ok {
+		return fmt.Errorf("SetKey: val must be int, string, or Series")
+	}
+	if df.numRows() > 0 && (df.numRows() != series.len()) {
+		return fmt.Errorf("SetKey: val len must match number of rows")
+	}
+
+	var newBody []Series
+	if columnIndex == -1 {
+		newBody = append([]Series{*series}, df.body...)
+	} else {
+		newBody = df.body
+		newBody[columnIndex] = *series
+	}
+	df.columns = NewIndex(newNames, "")
+	df.body = newBody
+	return nil
+}
+
+// Get returns a column of the DataFrame as a Series
+func (df *DataFrame) Get(keyVal starlark.Value) (value starlark.Value, found bool, err error) {
+	key, ok := toStrMaybe(keyVal)
+	if !ok {
+		return starlark.None, false, fmt.Errorf("Get key must be string")
+	}
+
+	// Find the column being retrieved, fail if not found
+	keyPos := findKeyPos(key, df.columns.texts)
+	if keyPos == -1 {
+		return starlark.None, false, fmt.Errorf("not found")
+	}
+
+	got := df.body[keyPos]
+	// TODO(dustmop): index should be the left-hand-side index, need a test
+	index := NewIndex(nil, "")
+
+	dtype := got.dtype
+	if dtype == "" {
+		dtype = dtypeFromWhich(got.which)
+	}
+
+	return &Series{
+		name:      key,
+		dtype:     dtype,
+		which:     got.which,
+		valInts:   got.valInts,
+		valFloats: got.valFloats,
+		valObjs:   got.valObjs,
+		index:     index,
+	}, true, nil
+}
+
+func (df *DataFrame) stringify() string {
+	// Get width of the left-hand label
+	labelWidth := 0
+	if df.index == nil {
+		bodyHeight := len(df.body)
+		k := len(fmt.Sprintf("%d", bodyHeight))
+		if k > labelWidth {
+			labelWidth = k
+		}
+	} else {
+		for _, str := range df.index.texts {
+			k := len(str)
+			if k > labelWidth {
+				labelWidth = k
+			}
+		}
+	}
+
+	// Create array of max widths, starting at 0
+	widths := make([]int, len(df.body))
+	for i, name := range df.columns.texts {
+		w := len(fmt.Sprintf("%s", name))
+		if w > widths[i] {
+			widths[i] = w
+		}
+	}
+	for i := 0; i < df.numRows(); i++ {
+		for j, col := range df.body {
+			elem := col.strAt(i)
+			w := len(elem)
+			if w > widths[j] {
+				widths[j] = w
+			}
+		}
+	}
+
+	// Render columns
+	header := make([]string, 0, len(df.columns.texts))
+	if len(df.columns.texts) > 0 {
+		// Render the column names
+		for i, name := range df.columns.texts {
+			tmpl := fmt.Sprintf("%%%ds", widths[i])
+			header = append(header, fmt.Sprintf(tmpl, name))
+		}
+	} else {
+		// Render the column indicies
+		for i := range df.body {
+			tmpl := fmt.Sprintf("%%%dd", widths[i])
+			header = append(header, fmt.Sprintf(tmpl, i))
+		}
+	}
+	padding := strings.Repeat(" ", labelWidth)
+	answer := fmt.Sprintf("%s    %s\n", padding, strings.Join(header, "  "))
+
+	// Render each row
+	for i := 0; i < df.numRows(); i++ {
+		render := []string{""}
+		// Render the index number or label to start the line
+		if df.index == nil {
+			tmpl := fmt.Sprintf("%%%dd  ", labelWidth)
+			render[0] = fmt.Sprintf(tmpl, i)
+		} else {
+			tmpl := fmt.Sprintf("%%%ds  ", labelWidth)
+			render[0] = fmt.Sprintf(tmpl, df.index.texts[i])
+		}
+		// Render each element of the row
+		for j, col := range df.body {
+			elem := col.strAt(i)
+			tmpl := fmt.Sprintf("%%%ds", widths[j])
+			render = append(render, fmt.Sprintf(tmpl, elem))
+		}
+		answer += strings.Join(render, "  ") + "\n"
+	}
+
+	return answer
+}
+
+func dtypeFromWhich(which int) string {
+	if which == typeInt {
+		return "int64"
+	} else if which == typeFloat {
+		return "float64"
+	}
+	return "object"
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1,0 +1,21 @@
+package dataframe
+
+import (
+	"testing"
+)
+
+func TestDataframeBasic(t *testing.T) {
+	runTestScript(t, "testdata/dataframe_basic.star", "testdata/dataframe_basic.expect.txt")
+}
+
+func TestDataframeSetKey(t *testing.T) {
+	runTestScript(t, "testdata/dataframe_setkey.star", "testdata/dataframe_setkey.expect.txt")
+}
+
+func TestDataframeGetKey(t *testing.T) {
+	runTestScript(t, "testdata/dataframe_getkey.star", "testdata/dataframe_getkey.expect.txt")
+}
+
+func TestDataframeColumns(t *testing.T) {
+	runTestScript(t, "testdata/dataframe_columns.star", "testdata/dataframe_columns.expect.txt")
+}

--- a/dataframe/index.go
+++ b/dataframe/index.go
@@ -1,0 +1,96 @@
+package dataframe
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+// Index represents a sequence used for indexing and aligning data.
+// Used for storing axis labels in a Series or DataFrame.
+type Index struct {
+	frozen bool
+	texts  []string
+	name   string
+}
+
+// NewIndex returns a new Index with the text values and name
+func NewIndex(texts []string, name string) *Index {
+	return &Index{texts: texts, name: name}
+}
+
+// Freeze prevents the index from being mutated
+func (i *Index) Freeze() {
+	i.frozen = true
+}
+
+// Hash cannot be used with Index
+func (i *Index) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: Index")
+}
+
+// String returns the index as a string
+func (i *Index) String() string {
+	result := make([]string, 0, len(i.texts))
+	for _, col := range i.texts {
+		text := fmt.Sprintf("'%s'", col)
+		result = append(result, text)
+	}
+	cols := strings.Join(result, ", ")
+	if i.name == "" {
+		return fmt.Sprintf("Index([%s], dtype='object')", cols)
+	}
+	return fmt.Sprintf("Index([%s], dtype='object', name='%s')", cols, i.name)
+}
+
+// Truth converts the index into a bool
+func (i *Index) Truth() starlark.Bool {
+	// NOTE: In python, calling bool(Index) raises this exception: "ValueError: The truth
+	// value of a Index is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all()."
+	// Since starlark does not have exceptions, just always return true.
+	return true
+}
+
+// Type returns the type as a string
+func (i *Index) Type() string {
+	return "dataframe.Index"
+}
+
+// Attr gets a value for a string attribute
+func (i *Index) Attr(name string) (starlark.Value, error) {
+	switch name {
+	case "name":
+		return starlark.String(i.name), nil
+	case "str":
+		return &stringMethods{subject: i}, nil
+	}
+	return nil, starlark.NoSuchAttrError(name)
+}
+
+// AttrNames lists available dot expression strings
+func (i *Index) AttrNames() []string {
+	return []string{"name", "str"}
+}
+
+func (i *Index) len() int {
+	if i == nil {
+		return 0
+	}
+	return len(i.texts)
+}
+
+func newIndex(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		dataVal, nameVal starlark.Value
+	)
+	if err := starlark.UnpackArgs("DataFrame", args, kwargs,
+		"data?", &dataVal,
+		"name?", &nameVal,
+	); err != nil {
+		return nil, err
+	}
+	data := toStrListOrNil(dataVal)
+	name := toStrOrEmpty(nameVal)
+	return NewIndex(data, name), nil
+}

--- a/dataframe/index_test.go
+++ b/dataframe/index_test.go
@@ -1,0 +1,16 @@
+package dataframe
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIndexStringify(t *testing.T) {
+	idx := NewIndex([]string{"cat", "dog", "eel"}, "animals")
+	actual := idx.String()
+	expect := `Index(['cat', 'dog', 'eel'], dtype='object', name='animals')`
+	if diff := cmp.Diff(expect, actual); diff != "" {
+		t.Errorf("error mismatch (-want +got):%s\n", diff)
+	}
+}

--- a/dataframe/series_test.go
+++ b/dataframe/series_test.go
@@ -19,3 +19,7 @@ func TestSeriesGet(t *testing.T) {
 func TestSeriesPrint(t *testing.T) {
 	runTestScript(t, "testdata/series_print.star", "testdata/series_print.expect.txt")
 }
+
+func TestSeriesIndexWithName(t *testing.T) {
+	runTestScript(t, "testdata/series_index_name.star", "testdata/series_index_name.expect.txt")
+}

--- a/dataframe/string_methods.go
+++ b/dataframe/string_methods.go
@@ -12,6 +12,12 @@ type stringMethods struct {
 	subject *Index
 }
 
+// compile-time interface assertions
+var (
+	_ starlark.Value    = (*stringMethods)(nil)
+	_ starlark.HasAttrs = (*stringMethods)(nil)
+)
+
 var stringMethodsMethods = map[string]*starlark.Builtin{
 	"lower":   starlark.NewBuiltin("lower", stringMethodsLower),
 	"replace": starlark.NewBuiltin("replace", stringMethodsReplace),
@@ -25,12 +31,12 @@ func (sm *stringMethods) Freeze() {
 
 // Hash cannot be used with stringMethods
 func (sm *stringMethods) Hash() (uint32, error) {
-	return 0, fmt.Errorf("unhashable: StringMethods")
+	return 0, fmt.Errorf("unhashable: %s", sm.Type())
 }
 
 // String returns a string representation of the stringMethods
 func (sm *stringMethods) String() string {
-	return "<class 'StringMethods'>"
+	return fmt.Sprintf("<%s>", sm.Type())
 }
 
 // Truth converts the stringMethods into a bool
@@ -40,7 +46,7 @@ func (sm *stringMethods) Truth() starlark.Bool {
 
 // Type returns the type as a string
 func (sm *stringMethods) Type() string {
-	return "dataframe.StringMethods"
+	return fmt.Sprintf("%s.StringMethods", Name)
 }
 
 // Attr gets a value for a string attribute

--- a/dataframe/string_methods.go
+++ b/dataframe/string_methods.go
@@ -1,0 +1,100 @@
+package dataframe
+
+import (
+	"fmt"
+	"strings"
+
+	"go.starlark.net/starlark"
+)
+
+// stringMethods provides access to string methods on string collection objects
+type stringMethods struct {
+	subject *Index
+}
+
+var stringMethodsMethods = map[string]*starlark.Builtin{
+	"lower":   starlark.NewBuiltin("lower", stringMethodsLower),
+	"replace": starlark.NewBuiltin("replace", stringMethodsReplace),
+	"strip":   starlark.NewBuiltin("strip", stringMethodsStrip),
+}
+
+// Freeze has no effect on the immutable stringMethods
+func (sm *stringMethods) Freeze() {
+	// pass
+}
+
+// Hash cannot be used with stringMethods
+func (sm *stringMethods) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable: StringMethods")
+}
+
+// String returns a string representation of the stringMethods
+func (sm *stringMethods) String() string {
+	return "<class 'StringMethods'>"
+}
+
+// Truth converts the stringMethods into a bool
+func (sm *stringMethods) Truth() starlark.Bool {
+	return true
+}
+
+// Type returns the type as a string
+func (sm *stringMethods) Type() string {
+	return "dataframe.StringMethods"
+}
+
+// Attr gets a value for a string attribute
+func (sm *stringMethods) Attr(name string) (starlark.Value, error) {
+	return builtinAttr(sm, name, stringMethodsMethods)
+}
+
+// AttrNames lists available attributes
+func (sm *stringMethods) AttrNames() []string {
+	return builtinAttrNames(stringMethodsMethods)
+}
+
+func stringMethodsLower(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	self := b.Receiver().(*stringMethods)
+	columns := self.subject.texts
+	result := make([]string, 0, len(columns))
+	for _, text := range columns {
+		lowerCol := strings.ToLower(text)
+		result = append(result, lowerCol)
+	}
+	return &Index{texts: result}, nil
+}
+
+func stringMethodsReplace(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var (
+		oldVal, newVal starlark.Value
+	)
+	if err := starlark.UnpackArgs("replace", args, kwargs,
+		"old", &oldVal,
+		"new", &newVal,
+	); err != nil {
+		return nil, err
+	}
+
+	self := b.Receiver().(*stringMethods)
+	oldText, _ := toStrMaybe(oldVal)
+	newText, _ := toStrMaybe(newVal)
+
+	columns := self.subject.texts
+	result := make([]string, 0, len(columns))
+	for _, text := range columns {
+		lowerCol := strings.Replace(text, oldText, newText, -1)
+		result = append(result, lowerCol)
+	}
+	return &Index{texts: result}, nil
+}
+
+func stringMethodsStrip(_ *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	self := b.Receiver().(*stringMethods)
+	columns := self.subject.texts
+	result := make([]string, 0, len(columns))
+	for _, text := range columns {
+		lowerCol := strings.Trim(text, " \t")
+		result = append(result, lowerCol)
+	}
+	return &Index{texts: result}, nil
+}

--- a/dataframe/testdata/dataframe_basic.expect.txt
+++ b/dataframe/testdata/dataframe_basic.expect.txt
@@ -1,0 +1,27 @@
+     id  animal  sound
+0     1     cat   meow
+1     2     dog   bark
+2     3     eel    zap
+
+
+           a          b        c
+0      apple     banana   cherry
+1    apricot  blueberry  currant
+
+
+      id      city      pop
+0    123  New York  8419000
+1    456   Chicago  2710000
+2    789  San Jose  1028000
+
+
+0    New York
+1     Chicago
+2    San Jose
+Name: city, dtype: object
+dataframe.Series
+
+             0    1     2
+   feline    1  cat  meow
+   canine    2  dog  bark
+anguillid    3  eel   zap

--- a/dataframe/testdata/dataframe_basic.star
+++ b/dataframe/testdata/dataframe_basic.star
@@ -1,0 +1,38 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  df = dataframe.DataFrame([[1,"cat","meow"],
+                            [2,"dog","bark"],
+                            [3,"eel","zap"]],
+                           columns=["id","animal","sound"])
+  print(df)
+  print('')
+
+  df = dataframe.DataFrame({"a": ["apple", "apricot"],
+                            "b": ["banana", "blueberry"],
+                            "c": ["cherry", "currant"]})
+  print(df)
+  print('')
+
+  df = dataframe.DataFrame({"id": [123, 456, 789],
+                            "city": ["New York", "Chicago", "San Jose"],
+                            "pop": [8419000, 2710000, 1028000]})
+  print(df)
+  print('')
+
+  series = df["city"]
+  print(series)
+  print(type(series))
+  print('')
+
+  df = dataframe.DataFrame([[1,"cat","meow"],
+                            [2,"dog","bark"],
+                            [3,"eel","zap"]],
+                           index=["feline","canine","anguillid"])
+  print(df)
+  print('')
+
+
+f()
+

--- a/dataframe/testdata/dataframe_columns.expect.txt
+++ b/dataframe/testdata/dataframe_columns.expect.txt
@@ -1,0 +1,11 @@
+Index([' First ', 'Second', 'Third Column'], dtype='object')
+Index([' first ', 'second', 'third column'], dtype='object')
+Index(['_First_', 'Second', 'Third_Column'], dtype='object')
+Index(['First', 'Second', 'Third Column'], dtype='object')
+Index(['first', 'second', 'third_column'], dtype='object')
+
+     first  second  third_column
+0      foo       1         300.1
+1      bar       2         301.2
+2      baz       3         303.4
+3      foo       5         305.7

--- a/dataframe/testdata/dataframe_columns.star
+++ b/dataframe/testdata/dataframe_columns.star
@@ -1,0 +1,30 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  df = dataframe.DataFrame({" First ": ["foo", "bar", "baz", "foo"],
+                            "Second": [1, 2, 3, 5],
+                            "Third Column": [300.1, 301.2, 303.4, 305.7]})
+
+  col = df.columns
+  print(df.columns)
+
+  col = df.columns.str.lower()
+  print(col)
+
+  col = df.columns.str.replace(' ', '_')
+  print(col)
+
+  col = df.columns.str.strip()
+  print(col)
+
+  col = df.columns.str.strip().str.lower().str.replace(' ', '_')
+  print(col)
+  print('')
+
+  df.columns = col
+  print(df)
+  print('')
+
+
+f()

--- a/dataframe/testdata/dataframe_getkey.expect.txt
+++ b/dataframe/testdata/dataframe_getkey.expect.txt
@@ -1,0 +1,16 @@
+     id  animal  sound
+0     1     cat   meow
+1     2     dog   bark
+2     3     eel    zap
+
+
+0    cat
+1    dog
+2    eel
+Name: animal, dtype: object
+
+0    1
+1    2
+2    3
+Name: id, dtype: int64
+

--- a/dataframe/testdata/dataframe_getkey.star
+++ b/dataframe/testdata/dataframe_getkey.star
@@ -1,0 +1,20 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  df = dataframe.DataFrame({"id": [1, 2, 3],
+                            "animal": ["cat", "dog", "eel"],
+                            "sound": ["meow", "bark", "zap"]})
+  print(df)
+  print('')
+
+  series = df['animal']
+  print(series)
+  print('')
+
+  series = df['id']
+  print(series)
+  print('')
+
+
+f()

--- a/dataframe/testdata/dataframe_setkey.expect.txt
+++ b/dataframe/testdata/dataframe_setkey.expect.txt
@@ -1,0 +1,30 @@
+case 0:
+     num  id  animal  sound
+0      7   1     cat   meow
+1      7   2     dog   bark
+2      7   3     eel    zap
+
+case 1:
+     num  id  animal  sound
+0      8   1     cat   meow
+1      8   2     dog   bark
+2      8   3     eel    zap
+
+case 2:
+     num  id  animal  sound
+0    abc   1     cat   meow
+1    abc   2     dog   bark
+2    abc   3     eel    zap
+
+case 3:
+     num  id  animal  sound
+0    123   1     cat   meow
+1    456   2     dog   bark
+2    789   3     eel    zap
+
+case 4:
+     more  num  id  animal  sound
+0     123  123   1     cat   meow
+1     456  456   2     dog   bark
+2     789  789   3     eel    zap
+

--- a/dataframe/testdata/dataframe_setkey.star
+++ b/dataframe/testdata/dataframe_setkey.star
@@ -1,0 +1,28 @@
+load("assert.star", "assert")
+load("dataframe.star", "dataframe")
+
+df = dataframe.DataFrame({"id": [1,2,3],
+                          "animal": ["cat","dog","eel"],
+                          "sound": ["meow","bark","zap"]})
+
+print('case 0:')
+df['num'] = 7
+print(df)
+
+print('case 1:')
+df['num'] = 8
+print(df)
+
+print('case 2:')
+df['num'] = 'abc'
+print(df)
+
+series = dataframe.Series([123,456,789])
+
+print('case 3:')
+df['num'] = series
+print(df)
+
+print('case 4:')
+df['more'] = series
+print(df)

--- a/dataframe/testdata/index.star
+++ b/dataframe/testdata/index.star
@@ -1,0 +1,9 @@
+load("assert.star", "assert")
+load("dataframe.star", "dataframe")
+
+fruits = dataframe.Index(["apple", "orange", "banana", "banana", "lemon", "apple", "banana"])
+
+assert.eq(
+  fruits.eq("banana"),
+  dataframe.Index(data=[False, False, True, True, False, False, True])
+)

--- a/dataframe/testdata/series_basic.expect.txt
+++ b/dataframe/testdata/series_basic.expect.txt
@@ -1,4 +1,3 @@
-
 case 0:
 0    123
 1    456
@@ -136,3 +135,11 @@ case 26:
 1    34.8
 2    56.7
 dtype: object
+
+case 27:
+0     True
+1     True
+2    False
+3     True
+4    False
+dtype: bool

--- a/dataframe/testdata/series_basic.star
+++ b/dataframe/testdata/series_basic.star
@@ -138,4 +138,9 @@ def f():
   print(series)
   print('')
 
+  print('case 27:')
+  series = dataframe.Series(data=[True, True, False, True, False])
+  print(series)
+  print('')
+
 f()

--- a/dataframe/testdata/series_index_name.expect.txt
+++ b/dataframe/testdata/series_index_name.expect.txt
@@ -1,0 +1,9 @@
+Index(['a', 'b', 'c'], dtype='object')
+
+Index(['a', 'b', 'c'], dtype='object', name='IDs')
+
+IDs
+a    123
+b    456
+c    789
+Name: Cool Data, dtype: int64

--- a/dataframe/testdata/series_index_name.star
+++ b/dataframe/testdata/series_index_name.star
@@ -1,0 +1,16 @@
+load("dataframe.star", "dataframe")
+
+def f():
+  index = dataframe.Index(data=['a', 'b', 'c'])
+  print(index)
+  print('')
+
+  index = dataframe.Index(data=['a', 'b', 'c'], name='IDs')
+  print(index)
+  print('')
+
+  series = dataframe.Series([123,456,789], index=index, name='Cool Data')
+  print(series)
+  print('')
+
+f()

--- a/dataframe/typed_array_builder.go
+++ b/dataframe/typed_array_builder.go
@@ -1,0 +1,197 @@
+package dataframe
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+type typedArrayBuilder struct {
+	size       int
+	keyList    []string
+	valInts    []int
+	valFloats  []float64
+	valObjs    []string
+	whichVals  int
+	dType      string
+	currType   string
+	buildError error
+}
+
+// A Series contains values of one of these three types. The which field uses these
+// constants to determine which slice holds the actual values of the Series.
+const (
+	typeInt   = 1
+	typeFloat = 2
+	typeObj   = 3
+)
+
+func newTypedArrayBuilder(size int) *typedArrayBuilder {
+	return &typedArrayBuilder{
+		size: size,
+	}
+}
+
+func (t *typedArrayBuilder) setType(dtype string) {
+	if dtype == "" {
+		return
+	}
+	t.dType = dtype
+	t.currType = dtype
+	if t.dType == "int64" || t.dType == "bool" {
+		t.whichVals = typeInt
+	} else if t.dType == "float64" {
+		t.whichVals = typeFloat
+	} else if t.dType == "object" {
+		t.whichVals = typeObj
+	} else if t.dType == "string" {
+		// TODO(dustmop): Is string a real type for pandas?
+		t.currType = "object"
+		t.whichVals = typeObj
+	} else {
+		t.buildError = fmt.Errorf("invalid dtype: %q", dtype)
+	}
+}
+
+func (t *typedArrayBuilder) push(val interface{}) {
+	if t.currType == "" {
+		// Initial data type
+		if num, ok := val.(int); ok {
+			t.currType = "int64"
+			t.whichVals = typeInt
+			_ = num
+		} else if f, ok := val.(float64); ok {
+			t.currType = "float64"
+			t.whichVals = typeFloat
+			_ = f
+		} else if text, ok := val.(string); ok {
+			t.currType = "object"
+			t.whichVals = typeObj
+			_ = text
+		} else if b, ok := val.(bool); ok {
+			t.currType = "bool"
+			t.whichVals = typeInt
+			val = 0
+			if b {
+				val = 1
+			}
+		} else {
+			t.buildError = fmt.Errorf("invalid object %v of type %s", val, reflect.TypeOf(val))
+			return
+		}
+	} else {
+		// Coerce types as needed
+		if num, ok := val.(int); ok {
+			if t.currType == "float64" {
+				val = float64(num)
+			} else if t.currType == "object" {
+				val = strconv.Itoa(num)
+			} else if t.currType != "int64" {
+				t.buildError = fmt.Errorf("handle coercion: %v to %q", num, t.currType)
+				return
+			}
+		} else if f, ok := val.(float64); ok {
+			// TODO(dustmop): If t.dType != "", is this an error?
+			if t.currType == "int64" && t.dType == "" {
+				// The list was ints, found a float, coerce the previous list to floats
+				t.currType = "float64"
+				t.whichVals = typeFloat
+				t.valFloats = convertIntsToFloats(t.valInts)
+			} else if t.currType == "object" {
+				//
+				val = stringifyFloat(f)
+			} else if t.currType != "float64" {
+				t.buildError = fmt.Errorf("handle coercion: %v to %q", f, t.currType)
+				return
+			}
+		} else if text, ok := val.(string); ok {
+			if t.currType == "int64" && t.dType == "" {
+				// The list was ints, found a string, coerce the previous list to objects
+				t.currType = "object"
+				t.whichVals = typeObj
+				t.valObjs = convertIntsToStrings(t.valInts)
+			} else if t.currType == "float64" && t.dType == "" {
+				// The list was floats, found a string, coerce the previous list to objects
+				t.currType = "object"
+				t.whichVals = typeObj
+				t.valObjs = convertFloatsToStrings(t.valFloats)
+			} else if t.currType != "object" {
+				t.buildError = fmt.Errorf("handle coercion: %v to %q", text, t.currType)
+				return
+			}
+		} else if b, ok := val.(bool); ok {
+			if t.currType == "bool" {
+				val = 0
+				if b {
+					val = 1
+				}
+			} else if t.currType != "bool" {
+				t.buildError = fmt.Errorf("handle coercion: %v to %q", text, t.currType)
+				return
+			}
+		} else {
+			t.buildError = fmt.Errorf("invalid object %v of type %s", val, reflect.TypeOf(val))
+			return
+		}
+	}
+
+	// Add to the appropriate array
+	if t.whichVals == typeInt {
+		if t.valInts == nil {
+			t.valInts = make([]int, 0, t.size)
+		}
+		t.valInts = append(t.valInts, val.(int))
+	} else if t.whichVals == typeFloat {
+		if t.valFloats == nil {
+			t.valFloats = make([]float64, 0, t.size)
+		}
+		t.valFloats = append(t.valFloats, val.(float64))
+	} else if t.whichVals == typeObj {
+		if t.valObjs == nil {
+			t.valObjs = make([]string, 0, t.size)
+		}
+		t.valObjs = append(t.valObjs, val.(string))
+	}
+}
+
+func (t *typedArrayBuilder) pushKeyVal(key string, val interface{}) {
+	t.keyList = append(t.keyList, key)
+	t.push(val)
+}
+
+func (t *typedArrayBuilder) parsePush(text string) {
+	// TODO: Parse a scalar from the text, push it. Used for csv reader.
+}
+
+func (t *typedArrayBuilder) error() error {
+	return t.buildError
+}
+
+func (t *typedArrayBuilder) keys() []string {
+	return t.keyList
+}
+
+func (t *typedArrayBuilder) dtype() string {
+	if t.dType == "" {
+		if t.currType != "" {
+			t.dType = t.currType
+		}
+	}
+	return t.dType
+}
+
+func (t *typedArrayBuilder) which() int {
+	return t.whichVals
+}
+
+func (t *typedArrayBuilder) asIntSlice() []int {
+	return t.valInts
+}
+
+func (t *typedArrayBuilder) asFloatSlice() []float64 {
+	return t.valFloats
+}
+
+func (t *typedArrayBuilder) asObjSlice() []string {
+	return t.valObjs
+}

--- a/dataframe/typed_slice_builder.go
+++ b/dataframe/typed_slice_builder.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 )
 
-type typedArrayBuilder struct {
+type typedSliceBuilder struct {
 	size       int
 	keyList    []string
 	valInts    []int
@@ -26,13 +26,13 @@ const (
 	typeObj   = 3
 )
 
-func newTypedArrayBuilder(size int) *typedArrayBuilder {
-	return &typedArrayBuilder{
+func newTypedArrayBuilder(size int) *typedSliceBuilder {
+	return &typedSliceBuilder{
 		size: size,
 	}
 }
 
-func (t *typedArrayBuilder) setType(dtype string) {
+func (t *typedSliceBuilder) setType(dtype string) {
 	if dtype == "" {
 		return
 	}
@@ -53,7 +53,7 @@ func (t *typedArrayBuilder) setType(dtype string) {
 	}
 }
 
-func (t *typedArrayBuilder) push(val interface{}) {
+func (t *typedSliceBuilder) push(val interface{}) {
 	if t.currType == "" {
 		// Initial data type
 		if num, ok := val.(int); ok {
@@ -154,44 +154,36 @@ func (t *typedArrayBuilder) push(val interface{}) {
 	}
 }
 
-func (t *typedArrayBuilder) pushKeyVal(key string, val interface{}) {
+func (t *typedSliceBuilder) pushKeyVal(key string, val interface{}) {
 	t.keyList = append(t.keyList, key)
 	t.push(val)
 }
 
-func (t *typedArrayBuilder) parsePush(text string) {
+func (t *typedSliceBuilder) parsePush(text string) {
 	// TODO: Parse a scalar from the text, push it. Used for csv reader.
 }
 
-func (t *typedArrayBuilder) error() error {
+func (t *typedSliceBuilder) error() error {
 	return t.buildError
 }
 
-func (t *typedArrayBuilder) keys() []string {
+func (t *typedSliceBuilder) keys() []string {
 	return t.keyList
 }
 
-func (t *typedArrayBuilder) dtype() string {
-	if t.dType == "" {
-		if t.currType != "" {
-			t.dType = t.currType
-		}
+// toSeries returns the series that has been built
+func (t *typedSliceBuilder) toSeries(index *Index, name string) Series {
+	dtype := t.dType
+	if dtype == "" && t.currType != "" {
+		dtype = t.currType
 	}
-	return t.dType
-}
-
-func (t *typedArrayBuilder) which() int {
-	return t.whichVals
-}
-
-func (t *typedArrayBuilder) asIntSlice() []int {
-	return t.valInts
-}
-
-func (t *typedArrayBuilder) asFloatSlice() []float64 {
-	return t.valFloats
-}
-
-func (t *typedArrayBuilder) asObjSlice() []string {
-	return t.valObjs
+	return Series{
+		dtype:     dtype,
+		which:     t.whichVals,
+		valInts:   t.valInts,
+		valFloats: t.valFloats,
+		valObjs:   t.valObjs,
+		index:     index,
+		name:      name,
+	}
 }

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
Index is used to store axis labels for Series and DataFrame. It has a name, and can be stringified. The text values in an index can be manipulated using stringMethods. A Series with an Index with a name will stringify with that name.

DataFrame exists, but only has a bit of functionality. It has columns, which are an index. It has an index which stringifies. DataFrame columns can be get'ed or set'ed, using Series objects. DataFrame can be constructed using a list or dict.

Build the series contents using a builder that handles all type coercion. This allows DataFrame to retain its actual input types. Series now handles boolean types.