### PR TITLE
feat(dataframe): Select rows from a dataframe using a bool series

### DIFF
--- a/dataframe/convert.go
+++ b/dataframe/convert.go
@@ -225,6 +225,11 @@ func convertToStarlark(it interface{}) (starlark.Value, error) {
 	switch x := it.(type) {
 	case int:
 		return starlark.MakeInt(x), nil
+	case bool:
+		if x {
+			return starlark.True, nil
+		}
+		return starlark.False, nil
 	case float64:
 		return starlark.Float(x), nil
 	case string:

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -1,89 +1,92 @@
 package dataframe
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/qri-io/starlib/testdata"
-	"go.starlark.net/starlark"
-	"go.starlark.net/starlarktest"
 )
 
 func TestDataframeBasic(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_basic.star", "testdata/dataframe_basic.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_basic.star", "testdata/dataframe_basic.expect.txt")
+}
+
+func TestDataframeBoolSelect(t *testing.T) {
+	expectScriptOutput(t, "testdata/dataframe_bool_select.star",
+		"testdata/dataframe_bool_select.expect.txt")
+}
+
+func TestDataframeBoolSelectDontUseEqualOperator(t *testing.T) {
+	_, err := runScript(t, "testdata/dataframe_bool_select_failure.star")
+	if err == nil {
+		t.Fatal("error expected, did not get one")
+	}
+	expectErr := "cannot call DataFrame.Get with bool. If you are trying `df[df[column] == val], instead use `df[df[column].equals(val)]`"
+	if err.Error() != expectErr {
+		t.Errorf("error mismatch\nwant: %s\ngot: %s", expectErr, err)
+	}
 }
 
 func TestDataframeSize(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_size.star", "testdata/dataframe_size.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_size.star", "testdata/dataframe_size.expect.txt")
 }
 
 func TestDataframeConcat(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_concat.star", "testdata/dataframe_concat.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_concat.star", "testdata/dataframe_concat.expect.txt")
 }
 
 func TestDataframeAt(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_at.star", "testdata/dataframe_at.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_at.star", "testdata/dataframe_at.expect.txt")
 }
 
 func TestDataframeSetKey(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_setkey.star", "testdata/dataframe_setkey.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_setkey.star", "testdata/dataframe_setkey.expect.txt")
 }
 
 func TestDataframeGetKey(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_getkey.star", "testdata/dataframe_getkey.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_getkey.star", "testdata/dataframe_getkey.expect.txt")
 }
 
 func TestDataframeApply(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_apply.star", "testdata/dataframe_apply.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_apply.star", "testdata/dataframe_apply.expect.txt")
 }
 
 func TestDataframeAppend(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_append.star", "testdata/dataframe_append.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_append.star", "testdata/dataframe_append.expect.txt")
 }
 
 func TestDataframeDropDuplicates(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_drop_duplicates.star",
+	expectScriptOutput(t, "testdata/dataframe_drop_duplicates.star",
 		"testdata/dataframe_drop_duplicates.expect.txt")
 }
 
 func TestDataframeHead(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_head.star", "testdata/dataframe_head.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_head.star", "testdata/dataframe_head.expect.txt")
 }
 
 func TestDataframeMerge(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_merge.star", "testdata/dataframe_merge.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_merge.star", "testdata/dataframe_merge.expect.txt")
 }
 
 func TestDataframeReadCSV(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_read_csv.star", "testdata/dataframe_read_csv.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_read_csv.star",
+		"testdata/dataframe_read_csv.expect.txt")
 }
 
 func TestDataframeResetIndex(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_reset_index.star", "testdata/dataframe_reset_index.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_reset_index.star",
+		"testdata/dataframe_reset_index.expect.txt")
 }
 
 func TestDataframeColumns(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_columns.star", "testdata/dataframe_columns.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_columns.star", "testdata/dataframe_columns.expect.txt")
 }
 
 func TestDataframeGroupBy(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_groupby.star", "testdata/dataframe_groupby.expect.txt")
+	expectScriptOutput(t, "testdata/dataframe_groupby.star", "testdata/dataframe_groupby.expect.txt")
 }
 
 func TestDataframeNotImplemented(t *testing.T) {
-	scriptFilename := "testdata/dataframe_not_implemented.star"
-
-	output := "\n"
-	printCollect := func(thread *starlark.Thread, msg string) {
-		output = fmt.Sprintf("%s%s\n", output, msg)
-	}
-
-	thread := &starlark.Thread{Load: testdata.NewModuleLoader(Module)}
-	thread.Print = printCollect
-	starlarktest.SetReporter(thread, t)
-
-	_, err := starlark.ExecFile(thread, scriptFilename, nil, nil)
+	_, err := runScript(t, "testdata/dataframe_not_implemented.star")
 	if err == nil {
 		t.Fatal("error expected, did not get one")
 	}

--- a/dataframe/series_test.go
+++ b/dataframe/series_test.go
@@ -5,29 +5,34 @@ import (
 )
 
 func TestSeriesBasic(t *testing.T) {
-	runTestScript(t, "testdata/series_basic.star", "testdata/series_basic.expect.txt")
+	expectScriptOutput(t, "testdata/series_basic.star", "testdata/series_basic.expect.txt")
 }
 
 func TestSeriesAttrs(t *testing.T) {
-	runTestScript(t, "testdata/series_attrs.star", "testdata/series_attrs.expect.txt")
+	expectScriptOutput(t, "testdata/series_attrs.star", "testdata/series_attrs.expect.txt")
 }
 
 func TestSeriesGet(t *testing.T) {
-	runTestScript(t, "testdata/series_get.star", "testdata/series_get.expect.txt")
+	expectScriptOutput(t, "testdata/series_get.star", "testdata/series_get.expect.txt")
 }
 
 func TestSeriesPrint(t *testing.T) {
-	runTestScript(t, "testdata/series_print.star", "testdata/series_print.expect.txt")
+	expectScriptOutput(t, "testdata/series_print.star", "testdata/series_print.expect.txt")
+}
+
+func TestSeriesBoolSelect(t *testing.T) {
+	expectScriptOutput(t, "testdata/series_bool_select.star",
+		"testdata/series_bool_select.expect.txt")
 }
 
 func TestSeriesIndexWithName(t *testing.T) {
-	runTestScript(t, "testdata/series_index_name.star", "testdata/series_index_name.expect.txt")
+	expectScriptOutput(t, "testdata/series_index_name.star", "testdata/series_index_name.expect.txt")
 }
 
 func TestSeriesAsType(t *testing.T) {
-	runTestScript(t, "testdata/series_astype.star", "testdata/series_astype.expect.txt")
+	expectScriptOutput(t, "testdata/series_astype.star", "testdata/series_astype.expect.txt")
 }
 
 func TestSeriesNotNull(t *testing.T) {
-	runTestScript(t, "testdata/series_notnull.star", "testdata/series_notnull.expect.txt")
+	expectScriptOutput(t, "testdata/series_notnull.star", "testdata/series_notnull.expect.txt")
 }

--- a/dataframe/test_runner_test.go
+++ b/dataframe/test_runner_test.go
@@ -12,7 +12,7 @@ import (
 	"go.starlark.net/starlarktest"
 )
 
-func runTestScript(t *testing.T, scriptFilename, expectFilename string) {
+func runScript(t *testing.T, scriptFilename string) (string, error) {
 	output := "\n"
 	printCollect := func(thread *starlark.Thread, msg string) {
 		output = fmt.Sprintf("%s%s\n", output, msg)
@@ -23,6 +23,11 @@ func runTestScript(t *testing.T, scriptFilename, expectFilename string) {
 	starlarktest.SetReporter(thread, t)
 
 	_, err := starlark.ExecFile(thread, scriptFilename, nil, nil)
+	return strings.Trim(output, "\n"), err
+}
+
+func expectScriptOutput(t *testing.T, scriptFilename, expectFilename string) {
+	output, err := runScript(t, scriptFilename)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dataframe/testdata/dataframe_bool_select.expect.txt
+++ b/dataframe/testdata/dataframe_bool_select.expect.txt
@@ -1,0 +1,22 @@
+     id  animal   sound
+0     1     cat    meow
+1     2     dog    bark
+2     3     eel     zap
+3     1     cat    meow
+4    20     dog   barks
+5     3     eel     zap
+6     4    frog  ribbit
+
+
+0    False
+1     True
+2    False
+3    False
+4     True
+5    False
+6    False
+Name: animal, dtype: bool
+
+     id  animal  sound
+1     2     dog   bark
+4    20     dog  barks

--- a/dataframe/testdata/dataframe_bool_select.star
+++ b/dataframe/testdata/dataframe_bool_select.star
@@ -1,0 +1,25 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  df = dataframe.DataFrame(columns=["id","animal","sound"],
+                           data=[[1,"cat","meow"],
+                                 [2,"dog","bark"],
+                                 [3,"eel","zap"],
+                                 [1,"cat","meow"],
+                                 [20,"dog","barks"],
+                                 [3,"eel","zap"],
+                                 [4,"frog","ribbit"]])
+  print(df)
+  print("")
+
+  is_id_three = df["animal"].equals("dog")
+  print(is_id_three)
+  print("")
+
+  selection = df[is_id_three]
+  print(selection)
+  print("")
+
+
+f()

--- a/dataframe/testdata/dataframe_bool_select_failure.star
+++ b/dataframe/testdata/dataframe_bool_select_failure.star
@@ -1,0 +1,26 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  df = dataframe.DataFrame(columns=["id","animal","sound"],
+                           data=[[1,"cat","meow"],
+                                 [2,"dog","bark"],
+                                 [3,"eel","zap"],
+                                 [1,"cat","meow"],
+                                 [20,"dog","barks"],
+                                 [3,"eel","zap"],
+                                 [4,"frog","ribbit"]])
+  print(df)
+  print("")
+
+  # Invalid way to create a bool series, binary equal operator doesn't work
+  is_id_three = df["animal"] == "dog"
+  print(is_id_three)
+  print("")
+
+  selection = df[is_id_three]
+  print(selection)
+  print("")
+
+
+f()

--- a/dataframe/testdata/series_attrs.expect.txt
+++ b/dataframe/testdata/series_attrs.expect.txt
@@ -1,1 +1,1 @@
-["astype", "get", "notnull"]
+["astype", "equals", "get", "notnull"]

--- a/dataframe/testdata/series_bool_select.expect.txt
+++ b/dataframe/testdata/series_bool_select.expect.txt
@@ -1,0 +1,22 @@
+0    123
+1    cat
+2    456
+3    789
+4    cat
+5    cat
+6    321
+dtype: object
+
+0    False
+1     True
+2    False
+3    False
+4     True
+5     True
+6    False
+dtype: bool
+
+1    cat
+4    cat
+5    cat
+dtype: object

--- a/dataframe/testdata/series_bool_select.star
+++ b/dataframe/testdata/series_bool_select.star
@@ -1,0 +1,18 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  series = dataframe.Series(data=['123','cat','456', '789', 'cat', 'cat', '321'])
+  print(series)
+  print('')
+
+  bools = series.equals('cat')
+  print(bools)
+  print('')
+
+  res = series[bools]
+  print(res)
+  print('')
+
+
+f()


### PR DESCRIPTION
This type of operation is now supported:

  ```
  res = df[df['type'].equals('important')]
  ```

Detect this invalid operation and display a helpful error message:

  ```
  res = df[df['type'] == 'important']
  ```