### PR TITLE
feat(dataframe): parse_csv to parse csv from text

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -26,6 +26,7 @@ var Module = &starlarkstruct.Module{
 	Name: Name,
 	Members: starlark.StringDict{
 		"read_csv":  starlark.NewBuiltin("read_csv", readCsv),
+		"parse_csv": starlark.NewBuiltin("parse_csv", parseCsv),
 		"DataFrame": starlark.NewBuiltin("DataFrame", newDataFrameBuiltin),
 		"Index":     starlark.NewBuiltin("Index", newIndex),
 		"Series":    starlark.NewBuiltin("Series", newSeries),
@@ -53,9 +54,13 @@ var (
 )
 
 func readCsv(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return starlark.None, fmt.Errorf("dataframe.read_csv is disabled, use dataframe.parse_csv(string) instead to parse csv text that was already downloaded using the http package. In the future, dataframe.read_csv(url) will be restored")
+}
+
+func parseCsv(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var content starlark.Value
 
-	if err := starlark.UnpackArgs("read_csv", args, kwargs,
+	if err := starlark.UnpackArgs("parse_csv", args, kwargs,
 		"content", &content,
 	); err != nil {
 		return nil, err

--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -82,7 +82,7 @@ func TestDataframeColumns(t *testing.T) {
 }
 
 func TestDataframeColumnsNone(t *testing.T) {
-	runTestScript(t, "testdata/dataframe_columns_none.star",
+	expectScriptOutput(t, "testdata/dataframe_columns_none.star",
 		"testdata/dataframe_columns_none.expect.txt")
 }
 

--- a/dataframe/testdata/dataframe_head.star
+++ b/dataframe/testdata/dataframe_head.star
@@ -2,7 +2,7 @@ load("dataframe.star", "dataframe")
 
 
 def f():
-  df = dataframe.read_csv("""id,animal,sound
+  df = dataframe.parse_csv("""id,animal,sound
 1,cat,meow
 2,dog,bark
 3,eel,zap

--- a/dataframe/testdata/dataframe_read_csv.star
+++ b/dataframe/testdata/dataframe_read_csv.star
@@ -2,7 +2,7 @@ load("dataframe.star", "dataframe")
 
 
 def f():
-  df = dataframe.read_csv("""id,animal,sound
+  df = dataframe.parse_csv("""id,animal,sound
 1,cat,meow
 2,dog,bark
 3,eel,zap


### PR DESCRIPTION
Prior to this, read_csv would parse csv from text. This was different from the pandas.DataFrame implementation, which would require a url to be passed to read_csv. This difference caused confusion. In the future, once the story around http access is fixed, the read_csv will be restored to match the pandas version.