### PR TITLE
starlib docs cleanup

### DIFF
--- a/compress/gzip/doc.go
+++ b/compress/gzip/doc.go
@@ -1,11 +1,10 @@
 /*Package gzip defines gzip encoding & decoding functions
 
-outline: gzip
-  decompress files like the GNU programs gzip and gunzip would.
-  path: compress/gzip
-  functions:
-    decompress(data) bytes
-      Decompress the data, returning a bytes object containing the uncompressed data.
-
+  outline: gzip
+    decompress files like the GNU programs gzip and gunzip would.
+    path: compress/gzip
+    functions:
+      decompress(data) bytes
+        Decompress the data, returning a bytes object containing the uncompressed data.
 */
 package gzip

--- a/encoding/csv/doc.go
+++ b/encoding/csv/doc.go
@@ -1,7 +1,7 @@
 /*Package csv reads comma-separated values files
 
   outline: csv
-    csv reads comma-separated values files
+    csv parses and writes comma-separated values files
     path: encoding/csv
     functions:
       read_all(source, comma=",", comment="", lazy_quotes=False, trim_leading_space=False, fields_per_record=0, skip=0) [][]string

--- a/encoding/json/doc.go
+++ b/encoding/json/doc.go
@@ -7,43 +7,43 @@ go.starlark.net/starlarkjson
 For source code see
 https://github.com/google/starlark-go/tree/master/lib/starlarkjson
 
-outline: json
-  json provides functions for working with json data
-  path: encoding/json
-  functions:
-    encode(obj) string
-      The encode function accepts one required positional argument,
-      which it converts to JSON by cases:
-      - A Starlark value that implements Go's standard json.Marshal
-        interface defines its own JSON encoding.
-      - None, True, and False are converted to null, true, and false, respectively.
-      - Starlark int values, no matter how large, are encoded as decimal integers.
-        Some decoders may not be able to decode very large integers.
-      - Starlark float values are encoded using decimal point notation,
-        even if the value is an integer.
-        It is an error to encode a non-finite floating-point value.
-      - Starlark strings are encoded as JSON strings, using UTF-16 escapes.
-      - a Starlark IterableMapping (e.g. dict) is encoded as a JSON object.
-        It is an error if any key is not a string.
-      - any other Starlark Iterable (e.g. list, tuple) is encoded as a JSON array.
-      - a Starlark HasAttrs (e.g. struct) is encoded as a JSON object.
-      It an application-defined type matches more than one the cases describe above,
-      (e.g. it implements both Iterable and HasFields), the first case takes precedence.
-      Encoding any other value yields an error.
-    decode(string) obj
-      The decode function accepts one positional parameter, a JSON string.
-      It returns the Starlark value that the string denotes.
-      - Numbers are parsed as int or float, depending on whether they
-        contain a decimal point.
-      - JSON objects are parsed as new unfrozen Starlark dicts.
-      - JSON arrays are parsed as new unfrozen Starlark lists.
-      Decoding fails if x is not a valid JSON string.
-    indent(string) string
-      The indent function pretty-prints a valid JSON encoding,
-      and returns a string containing the indented form.
-      It accepts one required positional parameter, the JSON string,
-      and two optional keyword-only string parameters, prefix and indent,
-      that specify a prefix of each new line, and the unit of indentation.
+  outline: json
+    json provides functions for working with json data
+    path: encoding/json
+    functions:
+      encode(obj) string
+        The encode function accepts one required positional argument,
+        which it converts to JSON by cases:
+        - A Starlark value that implements Go's standard json.Marshal
+          interface defines its own JSON encoding.
+        - None, True, and False are converted to null, true, and false, respectively.
+        - Starlark int values, no matter how large, are encoded as decimal integers.
+          Some decoders may not be able to decode very large integers.
+        - Starlark float values are encoded using decimal point notation,
+          even if the value is an integer.
+          It is an error to encode a non-finite floating-point value.
+        - Starlark strings are encoded as JSON strings, using UTF-16 escapes.
+        - a Starlark IterableMapping (e.g. dict) is encoded as a JSON object.
+          It is an error if any key is not a string.
+        - any other Starlark Iterable (e.g. list, tuple) is encoded as a JSON array.
+        - a Starlark HasAttrs (e.g. struct) is encoded as a JSON object.
+        It an application-defined type matches more than one the cases describe above,
+        (e.g. it implements both Iterable and HasFields), the first case takes precedence.
+        Encoding any other value yields an error.
+      decode(string) obj
+        The decode function accepts one positional parameter, a JSON string.
+        It returns the Starlark value that the string denotes.
+        - Numbers are parsed as int or float, depending on whether they
+          contain a decimal point.
+        - JSON objects are parsed as new unfrozen Starlark dicts.
+        - JSON arrays are parsed as new unfrozen Starlark lists.
+        Decoding fails if x is not a valid JSON string.
+      indent(string) string
+        The indent function pretty-prints a valid JSON encoding,
+        and returns a string containing the indented form.
+        It accepts one required positional parameter, the JSON string,
+        and two optional keyword-only string parameters, prefix and indent,
+        that specify a prefix of each new line, and the unit of indentation.
 */
 package json
 

--- a/hash/doc.go
+++ b/hash/doc.go
@@ -1,14 +1,14 @@
 /*Package hash defines hash primitives for starlark.
 
-  outline:
-	hash defines hash primitives for starlark.
-	path: hash
-	functions:
-	  md5(string) string
-	    returns an md5 hash for a string
-	  sha1(string) string
-	    returns an sha1 hash for a string
-	  sha256(string) string
-	    returns an sha256 hash for a string
+  outline: hash
+    hash defines hash primitives for starlark.
+    path: hash
+    functions:
+      md5(string) string
+        returns an md5 hash for a string
+      sha1(string) string
+        returns an sha1 hash for a string
+      sha256(string) string
+        returns an sha256 hash for a string
 */
 package hash


### PR DESCRIPTION
- removes some `sed` commands that were clearing subdirectories for docs pages (makefile will now write the corresponding markdown in a subdirectory if the source file is in a subdirectory, e.g. encoding/csv will end up in `/encoding/csv.md` instead of in the root of the starlib docs)

- adds missing indentations to `outline` documentation code, which was causing issues with display in the docs site.  This is a bug documented here: https://github.com/b5/outline/issues/5