### PR TITLE
feat: add Is() as isSelector()

### DIFF
--- a/html/doc.go
+++ b/html/doc.go
@@ -52,6 +52,11 @@
             params:
               selector string
                 a query selector string to filter the current selection, returning a new selection
+          isSelector(selector) bool
+            checks the current matched set of elements against a selector and returns true if at least one of these elements matches
+            params:
+              selector string
+                a query selector string to filter the current selection, returning a new selection
           parent(selector) selection
             gets the parent of each element in the Selection
             params:

--- a/html/html.go
+++ b/html/html.go
@@ -67,6 +67,7 @@ func (s *Selection) Struct() *starlarkstruct.Struct {
 		"filter":            starlark.NewBuiltin("filter", s.Filter),
 		"get":               starlark.NewBuiltin("get", s.Get),
 		"has":               starlark.NewBuiltin("has", s.Has),
+		"is_selector":        starlark.NewBuiltin("is_selector", s.Is),
 		"parent":            starlark.NewBuiltin("parent", s.Parent),
 		"parents_until":     starlark.NewBuiltin("parents_until", s.ParentsUntil),
 		"siblings":          starlark.NewBuiltin("siblings", s.Siblings),
@@ -218,6 +219,16 @@ func (s *Selection) Eq(thread *starlark.Thread, _ *starlark.Builtin, args starla
 
 	i, _ := x.Int64()
 	return NewSelectionStruct(s.sel.Eq(int(i))), nil
+}
+
+// Is checks the current matched set of elements against a selector and returns true if at least one of these elements matches.
+func (s *Selection) Is(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var x starlark.String
+	if err := starlark.UnpackPositionalArgs("is", args, kwargs, 1, &x); err != nil {
+		return nil, err
+	}
+
+	return starlark.Bool(s.sel.Is(string(x))), nil
 }
 
 // Len returns the length of the nodes in the selection

--- a/html/testdata/test.star
+++ b/html/testdata/test.star
@@ -46,4 +46,4 @@ assert.eq(p.parents_until("body").attr("class"), "le_div")
 assert.eq(p.siblings().text(), "Heading One")
 assert.eq(p.get(), ("p",))
 assert.eq(p.get(0), "p")
-
+assert.eq(p.is_selector("p"), True)


### PR DESCRIPTION
Using the `html` package, I needed a way to get the type of an element in a `selection`.  `goquery` has an `Is()` method which returns a bool if the selection includes a selector passed in as a string.

This PR adds `isSelector()` as a method on `structure`, because `is()` seems to be reserved (or at least when I tried using `is()` I got "not an identifier" errors, which cleared up when I used any other name).

