### PR TITLE
Use backticks for code

### DIFF
--- a/asset/doc_template.txt
+++ b/asset/doc_template.txt
@@ -33,9 +33,10 @@
 
 {{- end }}
 
-<code style="display: block; white-space: pre-wrap">
+```
 {{ .Code }}
-</code>
+```
+
 {{ end -}}
 {{- end -}}
 


### PR DESCRIPTION
Replaces `<code>` tags with 3 backticks in the template used to generate docs markdown files.  This ensures they will be parsed properly when the qri website is built.