### PR TITLE
fix(dataframe): When adding to a series, retain the existing type

### DIFF
--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -74,6 +74,11 @@ func TestDataframeAppend(t *testing.T) {
 	expectScriptOutput(t, "testdata/dataframe_append.star", "testdata/dataframe_append.expect.txt")
 }
 
+func TestDataframeTypeKeep(t *testing.T) {
+	expectScriptOutput(t, "testdata/dataframe_type_keep.star",
+		"testdata/dataframe_type_keep.expect.txt")
+}
+
 func TestDataframeDrop(t *testing.T) {
 	expectScriptOutput(t, "testdata/dataframe_drop.star", "testdata/dataframe_drop.expect.txt")
 }

--- a/dataframe/testdata/dataframe_type_keep.expect.txt
+++ b/dataframe/testdata/dataframe_type_keep.expect.txt
@@ -1,0 +1,3 @@
+         0      1      2   3
+0      cat   meow    1.2   3
+1    zebra  neigh  456.0  78

--- a/dataframe/testdata/dataframe_type_keep.star
+++ b/dataframe/testdata/dataframe_type_keep.star
@@ -1,0 +1,11 @@
+load("dataframe.star", "dataframe")
+
+
+def f():
+  df = dataframe.DataFrame([["cat", "meow", 1.2, 3]])
+  df = df.append([["zebra", "neigh", 456, 78]])
+  print(df)
+  print('')
+
+
+f()

--- a/dataframe/typed_slice_builder.go
+++ b/dataframe/typed_slice_builder.go
@@ -41,6 +41,7 @@ func newTypedSliceBuilderFromSeries(series *Series) *typedSliceBuilder {
 		valFloats: series.valFloats,
 		valObjs:   series.valObjs,
 		dType:     series.dtype,
+		currType:  series.dtype,
 	}
 }
 


### PR DESCRIPTION
Doing this is necessary to have correct logic when `push`ing to the builder. This ends up fixing a segfault that may be seen in the test case `dataframe_type_keep`