### PR TITLE
fix(dataframe): Append works with DataFrame args

### DIFF
--- a/dataframe/testdata/dataframe_append.expect.txt
+++ b/dataframe/testdata/dataframe_append.expect.txt
@@ -6,3 +6,11 @@
 0    cat  meow  123
 1    dog  bark  456
 2    eel   zap  789
+
+           0       1    2
+0        cat    meow  123
+1        dog    bark  456
+2        eel     zap  789
+3       frog  ribbit  321
+4    giraffe     hum  654
+5      hippo   grunt  987

--- a/dataframe/testdata/dataframe_append.star
+++ b/dataframe/testdata/dataframe_append.star
@@ -11,5 +11,12 @@ def f():
   print(df)
   print('')
 
+  other = dataframe.DataFrame([["frog", "ribbit", 321],
+                               ["giraffe", "hum", 654],
+                               ["hippo", "grunt", 987]])
+  df = df.append(other)
+  print(df)
+  print('')
+
 
 f()


### PR DESCRIPTION
Before, df = df.append(item) required item to be a starlark.List. With this change, it may also be another DataFrame.