### PR TITLE
fix(dataframe): Invariant that body is tabular, OutputConfig exists

### DIFF
--- a/dataframe/series.go
+++ b/dataframe/series.go
@@ -685,6 +685,9 @@ func newSeriesFromList(list starlark.List) (*Series, error) {
 }
 
 func newSeriesFromRepeatScalar(val interface{}, size int) *Series {
+	if val == nil {
+		return newSeriesFromObjects(make([]interface{}, size), nil, "")
+	}
 	switch x := val.(type) {
 	case int:
 		vals := make([]int, size)

--- a/dataframe/testdata/dataframe_append.expect.txt
+++ b/dataframe/testdata/dataframe_append.expect.txt
@@ -14,3 +14,25 @@
 3       frog  ribbit  321
 4    giraffe     hum  654
 5      hippo   grunt  987
+
+           0       1    2
+0        cat    meow  123
+1        dog    bark  456
+2        eel     zap  789
+3       frog  ribbit  321
+4    giraffe     hum  654
+5      hippo   grunt  987
+6     iguana  wheeze    0
+
+           0       1    2     3
+0        cat    meow  123  None
+1        dog    bark  456  None
+2        eel     zap  789  None
+3       frog  ribbit  321  None
+4    giraffe     hum  654  None
+5      hippo   grunt  987  None
+6     iguana  wheeze    0  None
+7     jaguar   growl  444   555
+
+          0      1    2    3
+0    jaguar  growl  444  555

--- a/dataframe/testdata/dataframe_append.star
+++ b/dataframe/testdata/dataframe_append.star
@@ -7,13 +7,33 @@ def f():
   print(df)
   print('')
 
+  # Append a list of lists (only 1 row)
   df = df.append([["eel", "zap", 789]])
   print(df)
   print('')
 
+  # Append a dataframe
   other = dataframe.DataFrame([["frog", "ribbit", 321],
                                ["giraffe", "hum", 654],
                                ["hippo", "grunt", 987]])
+  df = df.append(other)
+  print(df)
+  print('')
+
+  # Append with not enough columns
+  other = dataframe.DataFrame([["iguana", "wheeze"]])
+  df = df.append(other)
+  print(df)
+  print('')
+
+  # Append with too many columns
+  other = dataframe.DataFrame([["jaguar", "growl", 444, 555]])
+  df = df.append(other)
+  print(df)
+  print('')
+
+  # Append to an empty dataframe
+  df = dataframe.DataFrame()
   df = df.append(other)
   print(df)
   print('')


### PR DESCRIPTION
In order to avoid potential segfaults, we must ensure that DataFrames always have a tabular body; that each column has the same height. Use a single constructor everywhere that enforces this rule, as well as the existence of an OutputConfig. Update the append method so that rows of different sizes are handled correctly, by padding them with None values.