### PR TITLE
feat: allow proper nesting of methods under types

### DIFF
--- a/asset/doc_template.txt
+++ b/asset/doc_template.txt
@@ -83,7 +83,7 @@ weight: 2
 **Methods**
 
 {{- range .Methods -}}
-{{ template "mdFn" . }}
+{{ template "mdFnChild" . }}
 {{ end -}}
 {{- if gt (len .Operators) 0 }}
 
@@ -98,4 +98,52 @@ weight: 2
 {{ end }}
 {{- end -}}
 {{- end -}}
+{{ end }}
+
+{{- define "mdFnChild" }}
+
+#### {{ .FuncName }}
+
+```
+{{ .Signature }}
+```
+
+{{- if ne .Description "" }}
+
+{{ .Description }}
+
+{{- end -}}
+
+{{- if gt (len .Params) 0 }}
+
+##### parameters:
+
+| name | type | description |
+|------|------|-------------|
+{{ range .Params -}}
+| `{{ .Name }}` | `{{ .Type }}` | {{ .Description }} |
+{{ end -}}
+{{- end -}}
+
+{{- if gt (len .Examples) 0}}
+##### examples:
+{{ range .Examples -}}
+**{{ .Name }}**
+{{- if ne .Description "" }}
+
+{{ .Description }}
+
+{{- end }}
+
+```
+{{ .Code }}
+```
+
+{{ end -}}
+{{- end -}}
+
+{{- end -}}
+{{- range . -}}
+
+
 {{ end }}


### PR DESCRIPTION
Updates `doc_template`, defining a new template called `mdFnChild` which allows for proper nesting/hierarchy for `method`s that appear below a `Type` by making the method title an h4 instead of an h4, and its child headings h5 instead of h4.

This is necessary so that when rendered in our docs page, the `append` method of `Dataframe` appears smaller and lower in importance than its parent.  (Before they were rendered with the same level of importance, causing confusion)

![dataframe___Qri_io](https://user-images.githubusercontent.com/1833820/143132378-9435f3fa-4037-48f0-aed2-7ea15471ed49.png)
.
