### PR TITLE
feat(dataframe): Series math operations: add, subtract, abs

### DIFF
--- a/dataframe/dataframe.go
+++ b/dataframe/dataframe.go
@@ -29,6 +29,7 @@ var Module = &starlarkstruct.Module{
 		"DataFrame": starlark.NewBuiltin("DataFrame", newDataFrameBuiltin),
 		"Index":     starlark.NewBuiltin("Index", newIndex),
 		"Series":    starlark.NewBuiltin("Series", newSeries),
+		"abs":       starlark.NewBuiltin("mathAbs", mathAbs),
 	},
 }
 

--- a/dataframe/math.go
+++ b/dataframe/math.go
@@ -1,0 +1,41 @@
+package dataframe
+
+import (
+	"fmt"
+	"math"
+
+	"go.starlark.net/starlark"
+)
+
+func mathAbs(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	var subject starlark.Value
+
+	if err := starlark.UnpackArgs("abs", args, kwargs,
+		"subject", &subject,
+	); err != nil {
+		return nil, err
+	}
+
+	series, ok := subject.(*Series)
+	if !ok {
+		return starlark.None, fmt.Errorf("dataframe.abs can only be called on a Series")
+	}
+
+	builder := newTypedSliceBuilder(series.Len())
+	if series.which == typeInt {
+		// Fast math, all int series
+		for i := 0; i < series.Len(); i++ {
+			n := series.valInts[i]
+			if n < 0 {
+				n = -n
+			}
+			builder.push(n)
+		}
+	} else {
+		for i := 0; i < series.Len(); i++ {
+			builder.push(math.Abs(series.FloatAt(i)))
+		}
+	}
+	res := builder.toSeries(series.index, series.name)
+	return &res, nil
+}

--- a/dataframe/series_test.go
+++ b/dataframe/series_test.go
@@ -25,6 +25,10 @@ func TestSeriesIndexWithName(t *testing.T) {
 	expectScriptOutput(t, "testdata/series_index_name.star", "testdata/series_index_name.expect.txt")
 }
 
+func TestSeriesMath(t *testing.T) {
+	expectScriptOutput(t, "testdata/series_math.star", "testdata/series_math.expect.txt")
+}
+
 func TestSeriesAsType(t *testing.T) {
 	expectScriptOutput(t, "testdata/series_astype.star", "testdata/series_astype.expect.txt")
 }

--- a/dataframe/testdata/series_math.expect.txt
+++ b/dataframe/testdata/series_math.expect.txt
@@ -1,0 +1,34 @@
+a    123
+b    456
+c    789
+dtype: int64
+
+a    101
+b    505
+c    909
+dtype: int64
+
+a     224
+b     961
+c    1698
+dtype: int64
+
+a      22
+b     -49
+c    -120
+dtype: int64
+
+a       NaN
+b     557.0
+c    1294.0
+dtype: float64
+
+a     22
+b     49
+c    120
+dtype: int64
+
+a      NaN
+b    355.0
+c    284.0
+dtype: float64

--- a/dataframe/testdata/series_math.star
+++ b/dataframe/testdata/series_math.star
@@ -1,0 +1,33 @@
+load("dataframe.star", "dataframe")
+
+def f():
+  left = dataframe.Series([123,456,789], index=['a','b','c'])
+  print(left)
+  print('')
+
+  rite = dataframe.Series([101,505,909], index=['a','b','c'])
+  print(rite)
+  print('')
+
+  answer = left + rite
+  print(answer)
+  print('')
+
+  answer = left - rite
+  print(answer)
+  print('')
+
+  answer = left + rite.shift(1)
+  print(answer)
+  print('')
+
+  answer = dataframe.abs(left - rite)
+  print(answer)
+  print('')
+
+  answer = dataframe.abs(left - rite.shift(1))
+  print(answer)
+  print('')
+
+
+f()


### PR DESCRIPTION
Series can be added and subtracted to each other. Finally, we get to take advantage of the series struct storing slices of ints and floats by accessing them directly in a loop. Add a `dataframe.abs` function, which takes the `abs` of an entire series, one element at a time. Due to starlark's lack of ability to override builtins, we can't use the standard `abs` function.