### PR TITLE
fix(dataframe): Fix OutputConfig bugs

### DIFF
--- a/dataframe/dataframe_test.go
+++ b/dataframe/dataframe_test.go
@@ -140,7 +140,9 @@ func TestDataframeStringifyLarge(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	df, err := NewDataFrameFromCSV(string(csvText), nil)
+	outconf := &OutputConfig{}
+
+	df, err := NewDataFrameFromCSV(string(csvText), outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,11 +198,13 @@ func TestDataframeNotImplemented(t *testing.T) {
 type invalidData struct{}
 
 func TestDataframeFromRows(t *testing.T) {
+	outconf := &OutputConfig{}
+
 	// Construct a valid dataframe from a single row of various types of data
 	rows := [][]interface{}{}
 	record := []interface{}{"test", 31.2, 11.4, "ok", int64(597), "", 107, 6.91}
 	rows = append(rows, record)
-	df, err := NewDataFrame(rows, nil, nil, nil)
+	df, err := NewDataFrame(rows, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,7 +219,7 @@ func TestDataframeFromRows(t *testing.T) {
 	rows = [][]interface{}{}
 	record = []interface{}{"test", 31.2, &invalidData{}}
 	rows = append(rows, record)
-	_, err = NewDataFrame(rows, nil, nil, nil)
+	_, err = NewDataFrame(rows, nil, nil, outconf)
 	if err == nil {
 		t.Fatal("expected to get an error, did not get one")
 	}
@@ -230,7 +234,7 @@ func TestDataframeFromRows(t *testing.T) {
 	rows = append(rows, record)
 	record = []interface{}{"more", 9.8, 62, int64(3)}
 	rows = append(rows, record)
-	df, err = NewDataFrame(rows, nil, nil, nil)
+	df, err = NewDataFrame(rows, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +252,7 @@ func TestDataframeFromRows(t *testing.T) {
 	rows = append(rows, record)
 	record = []interface{}{25, "ok", int64(4), "hi"}
 	rows = append(rows, record)
-	df, err = NewDataFrame(rows, nil, nil, nil)
+	df, err = NewDataFrame(rows, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,8 +266,9 @@ func TestDataframeFromRows(t *testing.T) {
 }
 
 func TestDataframeFromList(t *testing.T) {
+	outconf := &OutputConfig{}
 	ls := []interface{}{1.2, 3.4, 5.6}
-	df, err := NewDataFrame(ls, nil, nil, nil)
+	df, err := NewDataFrame(ls, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -278,8 +283,9 @@ func TestDataframeFromList(t *testing.T) {
 }
 
 func TestDataframeFromSeries(t *testing.T) {
+	outconf := &OutputConfig{}
 	s := newSeriesFromObjects([]interface{}{"a", "b", "c"}, nil, "")
-	df, err := NewDataFrame(s, nil, nil, nil)
+	df, err := NewDataFrame(s, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -301,13 +307,15 @@ type someStruct struct {
 }
 
 func TestDataframeAccessor(t *testing.T) {
+	outconf := &OutputConfig{}
+
 	// Construct a dataframe with a few rows and columns
 	rows := [][]interface{}{
 		[]interface{}{"test", 31.2, 11.4, "ok", int64(597), "", 107, 6.91},
 		[]interface{}{"more", 7.8, 44.1, "hi", int64(612), "", 94, 3.1},
 		[]interface{}{"last", 90.2, 26.8, "yo", int64(493), "", 272, 4.3},
 	}
-	df, err := NewDataFrame(rows, nil, nil, nil)
+	df, err := NewDataFrame(rows, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -383,6 +391,8 @@ func TestDataframeAccessor(t *testing.T) {
 }
 
 func TestDataframeColumnNamesTypes(t *testing.T) {
+	outconf := &OutputConfig{}
+
 	// Construct a dataframe with a few rows and columns
 	rows := [][]interface{}{
 		[]interface{}{"test", 31.2, 11.4, "ok", int64(597), "", 107, 6.91},
@@ -390,7 +400,7 @@ func TestDataframeColumnNamesTypes(t *testing.T) {
 		[]interface{}{"last", 90.2, 26.8, "yo", int64(493), "", 272, 4.3},
 	}
 	columns := []string{"word", "num0", "num1", "text", "num64", "blank", "id", "amount"}
-	df, err := NewDataFrame(rows, columns, nil, nil)
+	df, err := NewDataFrame(rows, columns, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -417,6 +427,7 @@ func TestDataframeColumnNamesTypes(t *testing.T) {
 }
 
 func TestDataframeCopyAssignment(t *testing.T) {
+	outconf := &OutputConfig{}
 	rows := [][]interface{}{
 		[]interface{}{"test", 31.2, int64(597)},
 		[]interface{}{"more", 7.8, int64(612)},
@@ -425,7 +436,7 @@ func TestDataframeCopyAssignment(t *testing.T) {
 	columns := []string{"word", "num0", "num64"}
 	index := NewIndex([]string{"first", "second", "third"}, "labels")
 
-	df, err := NewDataFrame(rows, columns, index, nil)
+	df, err := NewDataFrame(rows, columns, index, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,7 +450,7 @@ second    more   7.8    612
 		t.Errorf("dataframe stringification mismatch (-want +got):%s\n", diff)
 	}
 
-	clone, err := NewDataFrame(df, nil, nil, nil)
+	clone, err := NewDataFrame(df, nil, nil, outconf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/dataframe/series.go
+++ b/dataframe/series.go
@@ -532,7 +532,7 @@ func seriesAttrSize(self *Series) (starlark.Value, error) {
 func adaptToSeriesFromDataframe(methodName string) starlarkMethod {
 	return func(thread *starlark.Thread, b *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		self := b.Receiver().(*Series)
-		outconf, _ := thread.Local("OutputConfig").(*OutputConfig)
+		outconf, _ := thread.Local(keyOutputConfig).(*OutputConfig)
 
 		// Convert the series to a DataFrame
 		df, err := NewDataFrame(self, nil, self.index, outconf)
@@ -641,7 +641,7 @@ func seriesToFrame(thread *starlark.Thread, b *starlark.Builtin, args starlark.T
 		return nil, err
 	}
 	self := b.Receiver().(*Series)
-	outconf, _ := thread.Local("OutputConfig").(*OutputConfig)
+	outconf, _ := thread.Local(keyOutputConfig).(*OutputConfig)
 	return NewDataFrame(self, nil, self.index, outconf)
 }
 
@@ -677,7 +677,7 @@ func seriesResetIndex(thread *starlark.Thread, b *starlark.Builtin, args starlar
 		return nil, err
 	}
 	self := b.Receiver().(*Series)
-	outconf, _ := thread.Local("OutputConfig").(*OutputConfig)
+	outconf, _ := thread.Local(keyOutputConfig).(*OutputConfig)
 
 	df, err := NewDataFrame(self, []string{"id"}, self.index, outconf)
 	if err != nil {

--- a/dataframe/test_runner_test.go
+++ b/dataframe/test_runner_test.go
@@ -22,6 +22,7 @@ func runScript(t *testing.T, scriptFilename string) (string, error) {
 	thread := &starlark.Thread{Load: testdata.NewModuleLoader(Module)}
 	thread.Print = printCollect
 	starlarktest.SetReporter(thread, t)
+	thread.SetLocal(keyOutputConfig, &OutputConfig{})
 
 	_, err := starlark.ExecFile(thread, scriptFilename, nil, nil)
 	return strings.Trim(output, "\n"), err

--- a/docs_test.go
+++ b/docs_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	outline "github.com/b5/outline/lib"
+	"github.com/qri-io/starlib/dataframe"
 	"go.starlark.net/starlark"
 )
 
@@ -56,6 +57,7 @@ func TestDocExamples(t *testing.T) {
 			t.Run(fmt.Sprintf("%s_%s", doc.Name, eg.Name), func(t *testing.T) {
 				printBuf := &bytes.Buffer{}
 				thread := &starlark.Thread{Load: Loader, Print: func(thread *starlark.Thread, msg string) { printBuf.WriteString(msg) }}
+				dataframe.SetOutputSize(thread, 0, 0)
 				g := starlark.StringDict{}
 				_, err := starlark.ExecFile(thread, eg.Name, eg.Code, g)
 				if err != nil {


### PR DESCRIPTION
Multiple bugs existed with OutputConfig, but their behavior masked each other. Validate that the supplied OutputConfig is non-nil, use a constant for the key name, and fix tests so that they ensure the intended behavior. Supply an exported function for callers to set their own OutputConfig.