### PR TITLE
feat(dataframe): First class support for timestamp values

### DIFF
--- a/dataframe/convert.go
+++ b/dataframe/convert.go
@@ -3,7 +3,10 @@ package dataframe
 import (
 	"fmt"
 	"reflect"
+	"strings"
+	gotime "time"
 
+	"go.starlark.net/lib/time"
 	"go.starlark.net/starlark"
 )
 
@@ -154,6 +157,14 @@ func toBoolMaybe(v starlark.Value) (bool, bool) {
 	return false, false
 }
 
+// convert starlark value to a go native time object
+func toTimeMaybe(v starlark.Value) (time.Time, bool) {
+	if tim, ok := v.(time.Time); ok {
+		return tim, true
+	}
+	return time.Time{}, false
+}
+
 // convert starlark value to go native int, bool, float, or string
 func toScalarMaybe(v starlark.Value) (interface{}, bool) {
 	if num, ok := toIntMaybe(v); ok {
@@ -167,6 +178,9 @@ func toScalarMaybe(v starlark.Value) (interface{}, bool) {
 	}
 	if b, ok := toBoolMaybe(v); ok {
 		return b, true
+	}
+	if tim, ok := toTimeMaybe(v); ok {
+		return tim, true
 	}
 	return nil, false
 }
@@ -205,6 +219,18 @@ func toIndexMaybe(v starlark.Value) (*Index, bool) {
 		return index, true
 	}
 	return nil, false
+}
+
+func timeToInt(t time.Time) int {
+	gt := gotime.Time(t)
+	num := gt.Unix() * 1000000000
+	return int(num)
+}
+
+func intTimestampToString(n int) string {
+	t := gotime.Unix(int64(n/1000000000), 0)
+	ans := t.UTC().Format("2006-01-02 15:04:05")
+	return strings.TrimSuffix(ans, " 00:00:00")
 }
 
 func stringifyFloat(f float64) string {

--- a/dataframe/series_test.go
+++ b/dataframe/series_test.go
@@ -42,6 +42,10 @@ func TestSeriesResetIndex(t *testing.T) {
 		"testdata/series_reset_index.expect.txt")
 }
 
+func TestSeriesTime(t *testing.T) {
+	expectScriptOutput(t, "testdata/series_time.star", "testdata/series_time.expect.txt")
+}
+
 func TestSeriesToFrame(t *testing.T) {
 	expectScriptOutput(t, "testdata/series_to_frame.star", "testdata/series_to_frame.expect.txt")
 }

--- a/dataframe/test_runner_test.go
+++ b/dataframe/test_runner_test.go
@@ -3,14 +3,35 @@ package dataframe
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/qri-io/starlib/testdata"
+	"go.starlark.net/lib/time"
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarktest"
 )
+
+func loadModule(thread *starlark.Thread, module string) (starlark.StringDict, error) {
+	switch module {
+	case "dataframe.star":
+		return starlark.StringDict{"dataframe": Module}, nil
+	case "time.star":
+		return starlark.StringDict{"time": time.Module}, nil
+	case "assert.star":
+		starlarktest.DataFile = func(pkgdir, filename string) string {
+			_, currFileName, _, ok := runtime.Caller(1)
+			if !ok {
+				return ""
+			}
+			return filepath.Join(filepath.Dir(currFileName), filename)
+		}
+		return starlarktest.LoadAssertModule()
+	}
+	return nil, fmt.Errorf("invalid module")
+}
 
 func runScript(t *testing.T, scriptFilename string) (string, error) {
 	t.Helper()
@@ -19,7 +40,7 @@ func runScript(t *testing.T, scriptFilename string) (string, error) {
 		output = fmt.Sprintf("%s%s\n", output, msg)
 	}
 
-	thread := &starlark.Thread{Load: testdata.NewModuleLoader(Module)}
+	thread := &starlark.Thread{Load: loadModule}
 	thread.Print = printCollect
 	starlarktest.SetReporter(thread, t)
 	thread.SetLocal(keyOutputConfig, &OutputConfig{})

--- a/dataframe/testdata/series_time.expect.txt
+++ b/dataframe/testdata/series_time.expect.txt
@@ -1,0 +1,19 @@
+0    2021-03-21
+1    2021-05-04
+dtype: datetime64[ns]
+
+0     apple
+1    banana
+dtype: object
+
+           when   names
+0    2021-03-21   apple
+1    2021-05-04  banana
+
+0    1616284800000000000
+1    1620086400000000000
+dtype: int64
+
+0    2021-03-21
+1    2021-05-04
+dtype: datetime64[ns]

--- a/dataframe/testdata/series_time.star
+++ b/dataframe/testdata/series_time.star
@@ -1,0 +1,29 @@
+load("dataframe.star", "dataframe")
+load("time.star", "time")
+
+
+def f():
+  a = time.time(year=2021, month=3, day=21)
+  b = time.time(year=2021, month=5, day=4)
+  when = dataframe.Series([a, b])
+  print(when)
+  print('')
+
+  names = dataframe.Series(['apple', 'banana'])
+  print(names)
+  print('')
+
+  df = dataframe.DataFrame({'when': when, 'names': names})
+  print(df)
+  print('')
+
+  counts = when.astype('int')
+  print(counts)
+  print('')
+
+  dts = counts.astype('datetime64[ns]')
+  print(dts)
+  print('')
+
+
+f()


### PR DESCRIPTION
Dataframe and Series now allow time.Time objects. Can be added as values, instead of needing to be represented as strings. Timestamps are now stored as ints, using the dtype 'datetime64[ns]'.

The `astype` method no longer needs to parse when converting ints to timestamps or vice versa.