### PR TITLE
Ensure Content-Length is Sent

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -234,6 +234,8 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, f
 			return err
 		}
 		req.Body = ioutil.NopCloser(strings.NewReader(uq))
+		req.ContentLength = int64(len(uq))
+
 		return nil
 	}
 
@@ -249,6 +251,7 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, f
 			return err
 		}
 		req.Body = ioutil.NopCloser(bytes.NewBuffer(data))
+		req.ContentLength = int64(len(data))
 	}
 
 	if formData != nil && formData.Len() > 0 {
@@ -279,6 +282,7 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, f
 		case formEncodingURL, "":
 			contentType = formEncodingURL
 			req.Body = ioutil.NopCloser(strings.NewReader(form.Encode()))
+			req.ContentLength = int64(len(form.Encode()))
 
 		case formEncodingMultipart:
 			var b bytes.Buffer

--- a/http/http.go
+++ b/http/http.go
@@ -234,6 +234,8 @@ func setBody(req *http.Request, body starlark.String, formData *starlark.Dict, f
 			return err
 		}
 		req.Body = ioutil.NopCloser(strings.NewReader(uq))
+		// Specifying the Content-Length ensures that https://go.dev/src/net/http/transfer.go doesnt specify Transfer-Encoding: chunked which is not supported by some endpoints.
+		// This is required when using ioutil.NopCloser method for the request body (see ShouldSendChunkedRequestBody() in the library mentioned above).
 		req.ContentLength = int64(len(uq))
 
 		return nil


### PR DESCRIPTION
Added specification of Content-Length during creation of the Request Body for URL Encoded and JSON Encoded content.   

The existing implementation uses the ioutil.NopCloser method to create the Request body, which triggers ShouldSendChunkedRequestBody in https://go.dev/src/net/http/transfer.go that results in the Request Header specifying Transfer-Encoding: Chunked.

This change enables compatibility with Endpoints (such as Microsoft Graph APIs) that do not support Transfer-Encoding: Chunked

Testing: I've rebuilt the new http.go library into the Pixlet application: https://github.com/tidbyt/pixlet and hit multiple endpoints at Google and MSFT cloud with successful result (about 10 different API calls)