### PR TITLE
feat(hmac): Initial HMAC module

### DIFF
--- a/hmac/README.md
+++ b/hmac/README.md
@@ -1,0 +1,17 @@
+# hmac
+
+hmac defines hmac primitives for starlark
+
+## Functions
+
+#### `md5(key, string) string`
+
+returns md5 hash of a string using the provided key
+
+#### `sha1(key, string) string`
+
+returns sha1 hash of a string using the provided key
+
+#### `sha256(key, string) string`
+
+returns sha256 hash of a string using the provided key

--- a/hmac/doc.go
+++ b/hmac/doc.go
@@ -1,0 +1,38 @@
+/*Package hmac defines hash primitives for starlark.
+
+  outline: hmac
+    hmac defines hmac primitives for starlark.
+    path: hmac
+    functions:
+      md5(key, string) string
+        returns an md5 hash for a string with a key of "secret"
+        examples:
+          basic
+            calculate an md5 checksum for "hello world" with a key of "secret"
+            code:
+              load("hmac.star", "hmac")
+              sum = hmac.md5("secret", "hello world!")
+              print(sum)
+              # Output: 0a0461e10e89506d7c31a145663bed93
+      sha1(key, string) string
+        returns a SHA1 hash for a string
+        examples:
+          basic
+            calculate an SHA1 checksum for "hello world" with a key of "secret"
+            code:
+              load("hmac.star", "hmac")
+              sum = hmac.sha1("secret", "hello world!")
+              print(sum)
+              # Output: a4df5f9d237ab0ca3241f042bcf6059a4ef491c4
+      sha256(key, string) string
+        returns an SHA2-256 hash for a string
+        examples:
+          basic
+            calculate an SHA2-256 checksum for "hello world" with a key of "secret"
+            code:
+              load("hmac.star", "hmac")
+              sum = hmac.sha256("secret", "hello world!")
+              print(sum)
+              # Output: 72069731bf291b463aecb218bc227abce3d403d76da67faef2d48d3cb43b2f54
+*/
+package hmac

--- a/hmac/hmac.go
+++ b/hmac/hmac.go
@@ -1,0 +1,63 @@
+package hmac
+
+import (
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"sync"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+)
+
+// ModuleName defines the expected name for this Module when used
+// in starlark's load() function, eg: load('hmac.star', 'hmac')
+const ModuleName = "hmac.star"
+
+var (
+	once       sync.Once
+	hmacModule starlark.StringDict
+	hmacError  error
+)
+
+// LoadModule loads the time module.
+// It is concurrency-safe and idempotent
+func LoadModule() (starlark.StringDict, error) {
+	once.Do(func() {
+		hmacModule = starlark.StringDict{
+			"hmac": &starlarkstruct.Module{
+				Name: "hmac",
+				Members: starlark.StringDict{
+					"md5":    starlark.NewBuiltin("hmac.md5", fnHmac(md5.New)),
+					"sha1":   starlark.NewBuiltin("hmac.sha1", fnHmac(sha1.New)),
+					"sha256": starlark.NewBuiltin("hmac.sha256", fnHmac(sha256.New)),
+				},
+			},
+		}
+
+	})
+	return hmacModule, hmacError
+
+}
+
+func fnHmac(hashFunc func() hash.Hash) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var (
+			key starlark.String
+			s 	starlark.String
+		)
+		if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &key, &s); err != nil {
+			return nil, err
+		}
+
+		h :=  hmac.New(hashFunc, []byte(string(key)))
+
+		if _, err := h.Write([]byte(string(s))); err != nil {
+			return starlark.None, err
+		}
+		return starlark.String(fmt.Sprintf("%x", h.Sum(nil))), nil
+	}
+}

--- a/hmac/hmac_test.go
+++ b/hmac/hmac_test.go
@@ -1,0 +1,22 @@
+package hmac
+
+import (
+	"testing"
+
+	"github.com/qri-io/starlib/testdata"
+	"go.starlark.net/resolve"
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarktest"
+)
+
+func TestFile(t *testing.T) {
+	resolve.AllowFloat = true
+	thread := &starlark.Thread{Load: testdata.NewLoader(LoadModule, ModuleName)}
+	starlarktest.SetReporter(thread, t)
+
+	// Execute test file
+	_, err := starlark.ExecFile(thread, "testdata/test.star", nil, nil)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/hmac/testdata/test.star
+++ b/hmac/testdata/test.star
@@ -1,0 +1,9 @@
+"""
+Test data for hmac module
+"""
+load('hmac.star', 'hmac')
+load('assert.star', 'assert')
+
+assert.eq(hmac.md5("secret", "helloworld"), "8bd4df4530c3c2cafabf6986740e44bd")
+assert.eq(hmac.sha1("secret", "helloworld"), "e92eb69939a8b8c9843a75296714af611c73fb53")
+assert.eq(hmac.sha256("secret", "helloworld"), "7a7c2bf41973489be3b318ad2f16c75fc875c340deecb12a3f79b28bb7135c97")

--- a/starlib.go
+++ b/starlib.go
@@ -12,6 +12,7 @@ import (
 	"github.com/qri-io/starlib/encoding/yaml"
 	"github.com/qri-io/starlib/geo"
 	"github.com/qri-io/starlib/hash"
+	"github.com/qri-io/starlib/hmac"
 	"github.com/qri-io/starlib/html"
 	"github.com/qri-io/starlib/http"
 	"github.com/qri-io/starlib/math"
@@ -58,6 +59,8 @@ func Loader(thread *starlark.Thread, module string) (dict starlark.StringDict, e
 		return starlark.StringDict{"math": math.Module}, nil
 	case hash.ModuleName:
 		return hash.LoadModule()
+	case hmac.ModuleName:
+		return hmac.LoadModule()
 	case dataframe.ModuleName:
 		return starlark.StringDict{"dataframe": dataframe.Module}, nil
 	}


### PR DESCRIPTION
This PR adds basic support for generating hmac hashes using the same algorithms supported by the hash module. Closes #168.