### PR TITLE
fix: add support for marshalling and unmarshalling bytes

### DIFF
--- a/util/util.go
+++ b/util/util.go
@@ -150,6 +150,8 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 		} else {
 			err = fmt.Errorf("constructor object from *starlarkstruct.Struct not supported Marshaler to starlark object: %s", v.Constructor().Type())
 		}
+	case starlark.Bytes:
+		val = []byte(v)
 	default:
 		fmt.Println("errbadtype:", x.Type())
 		err = fmt.Errorf("unrecognized starlark type: %s", x.Type())

--- a/util/util.go
+++ b/util/util.go
@@ -194,6 +194,8 @@ func Marshal(data interface{}) (v starlark.Value, err error) {
 		v = starlark.Float(x)
 	case time.Time:
 		v = startime.Time(x)
+	case []byte:
+		v = starlark.Bytes(x)
 	case []interface{}:
 		var elems = make([]starlark.Value, len(x))
 		for i, val := range x {

--- a/util/util.go
+++ b/util/util.go
@@ -41,6 +41,8 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 		} else {
 			val = f
 		}
+	case starlark.Bytes:
+		val = []byte(v)
 	case starlark.String:
 		val = v.GoString()
 	case startime.Time:
@@ -150,8 +152,6 @@ func Unmarshal(x starlark.Value) (val interface{}, err error) {
 		} else {
 			err = fmt.Errorf("constructor object from *starlarkstruct.Struct not supported Marshaler to starlark object: %s", v.Constructor().Type())
 		}
-	case starlark.Bytes:
-		val = []byte(v)
 	default:
 		fmt.Println("errbadtype:", x.Type())
 		err = fmt.Errorf("unrecognized starlark type: %s", x.Type())


### PR DESCRIPTION
fixes #172

```starlark
def fibonacci(n):
    res = list(range(n))
    for i in res[2:]:
        res[i] = res[i-2] + res[i-1]
    return bytes(res)

print(fibonacci(4))
```

```go
package main

import (
	"fmt"

	"github.com/qri-io/starlib/util"
	"go.starlark.net/starlark"
)

func main() {
	// Execute Starlark program in a file.
	thread := &starlark.Thread{Name: "my thread"}
	globals, err := starlark.ExecFile(thread, "fibonacci.star", nil, nil)
	if err != nil {
		panic(err)
	}

	// Retrieve a module global.
	fibonacci := globals["fibonacci"]

	// Call Starlark function from Go.
	v, err := starlark.Call(thread, fibonacci, starlark.Tuple{starlark.MakeInt(10)}, nil)
	if err != nil {
		panic(err)
	}
	vI, err := util.Unmarshal(v)
	if err != nil {
		panic(err)
	}
	fmt.Printf("fibonacci(10) = %+v\n", vI) // fibonacci(10) = [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]
}
```

```console
$ go run main.go 

errbadtype: bytes
panic: unrecognized starlark type: bytes

goroutine 1 [running]:
main.main()
	/Users/user/Desktop/test-star/main.go:28 +0x185
exit status 2
$ echo 'after replacing with my branch in go.mod'
$ go mod tidy
go: downloading github.com/HarikrishnanBalagopal/starlib v0.5.0-alpha.0
$ go run main.go 

fibonacci(10) = [0 1 1 2 3 5 8 13 21 34]
```
