### PR TITLE
encoding/yaml: Add support for multi-document serialization

### DIFF
--- a/encoding/yaml/README.md
+++ b/encoding/yaml/README.md
@@ -1,25 +1,27 @@
 # yaml
-yaml provides functions for working with yaml data
+yaml provides functions for working with yaml data.
 
 ## Functions
 
-#### `dumps(obj) string`
-serialize obj to a yaml string
+#### `dumps(obj, [obj, ...]) string`
+Serialize one or more objects to a yaml string.
+
+If more than one object is provided, the returned string will use
+YAML's [Multi-Document](https://yaml.org/spec/1.2.2/#example-two-documents-in-a-stream)
+format.
 
 **parameters:**
 
-| name | type | description |
-|------|------|-------------|
-| `obj` | `object` | input object |
+| name  | type     | description     |
+| ----- | -------- | --------------- |
+| `obj` | `object` | input object(s) |
 
 
 #### `loads(source) object`
-read a source yaml string to a starlark object
+Read a source yaml string to a Starlark object.
 
 **parameters:**
 
-| name | type | description |
-|------|------|-------------|
+| name     | type     | description               |
+| -------- | -------- | ------------------------- |
 | `source` | `string` | input string of yaml data |
-
-

--- a/encoding/yaml/testdata/test.star
+++ b/encoding/yaml/testdata/test.star
@@ -1,6 +1,5 @@
-
-load('encoding/yaml.star', 'yaml')
-load('assert.star', 'assert')
+load("encoding/yaml.star", "yaml")
+load("assert.star", "assert")
 
 yaml_list = """- Apple
 - Orange
@@ -9,7 +8,7 @@ yaml_list = """- Apple
 """
 
 native_list = ["Apple", "Orange", "Strawberry", "Mango"]
-assert.eq(yaml.loads(yaml_list), native_list) 
+assert.eq(yaml.loads(yaml_list), native_list)
 assert.eq(yaml.dumps(native_list), yaml_list)
 
 yaml_dict = """martin:
@@ -22,3 +21,5 @@ native_dict = {"martin": {"name": "Martin D'vloper", "job": "Developer", "skill"
 assert.eq(yaml.loads(yaml_dict), native_dict)
 assert.eq(yaml.dumps(native_dict), yaml_dict)
 
+multidoc_yaml = "---\n".join([yaml_list, yaml_dict])
+assert.eq(yaml.dumps(native_list, native_dict), multidoc_yaml)


### PR DESCRIPTION
## Intent
To add support for multi-document serialization to the `encoding/yaml` module.

## Problem
The current implementation of the YAML module does not allow the generation of a multi-document YAML stream.

## Solution
To re-work the `yaml.Dumps` implementation to support the feature while ensuring backward compatibility.